### PR TITLE
Add volume creation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ See the [tasklist](https://www.notion.so/a3m-acfaae80a800407b80317b7efd3b76bf) f
 
 Get started with:
 
-    $ make build bootstrap restart
+    $ make create-volumes build bootstrap restart
 
 Ports exposed in Docker Compose:
 


### PR DESCRIPTION
Otherwise `make build` fails with:

```
env COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose up -d --force-recreate
WARNING: Native build is an experimental feature and could change at any time
Creating network "a3m_default" with the default driver
ERROR: Volume a3m-pipeline-data declared as external, but could not be found. Please create the volume manually using `docker volume create --name=a3m-pipeline-data` and try again.
Makefile:9: recipe for target 'build' failed
make: *** [build] Error 1
```