### PR TITLE
Update development environment

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,14 +20,14 @@ jobs:
     steps:
     - name: Check out source code
       uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python }}
-        architecture: x64
-    - name: Install dependencies
-      run: python -m pip install --upgrade wheel setuptools pip tox virtualenv
-    - run: tox -e ${{ matrix.tox }}
+    - name: "Create external volume"
+      run: |
+        make create-volume
+    - name: "Run toxenv"
+      run: |
+        make tox ARG=${{ matrix.tox }}
+      env:
+        PYTHON_VERSION: ${{ matrix.python }}
     - name: Codecov
       uses: codecov/codecov-action@v1
       with:

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,53 @@
 .DEFAULT_GOAL := help
 
+export COMPOSE_DOCKER_CLI_BUILD=1
+export DOCKER_BUILDKIT=1
+export BUILDKIT_PROGRESS=plain
+
 A3M_PIPELINE_DATA ?= $(CURDIR)/hack/compose-volume
 
 CURRENT_UID := $(shell id -u)
+CURRENT_GID := $(shell id -g)
 
+NULL :=
+SPACE := $(NULL) $(NULL)
 
+define compose
+	docker-compose -f docker-compose.yml $(1)
+endef
+
+define compose_run
+	$(call compose, \
+		run \
+		--rm \
+		--user=$(CURRENT_UID):$(CURRENT_GID) \
+		--workdir /a3m \
+		--no-deps \
+		$(1))
+endef
+
+define toxenvs
+	$(call compose_run, \
+		--entrypoint tox \
+			a3m \
+				$(subst $(SPACE), -e ,$(SPACE)$(1)) \
+				${TOXARGS})
+endef
+
+.PHONY: shell
 shell:  ## Open a shell in a new container.
-	docker-compose run --rm --entrypoint bash a3m
+	$(call compose_run, \
+		--entrypoint bash \
+		a3m)
 
 .PHONY: build
-build:  ## Build and recreate containers.
-	env COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose build
-	env COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose up -d --force-recreate
+build:  ## Build containers.
+	$(call compose, \
+		build \
+		--build-arg USER_ID=$(CURRENT_UID) \
+		--build-arg GROUP_ID=$(CURRENT_GID))
 
+.PHONY: create-volume
 create-volume:  ## Create external data volume.
 	mkdir -p ${A3M_PIPELINE_DATA}
 	docker volume create \
@@ -21,71 +56,100 @@ create-volume:  ## Create external data volume.
 		--opt device=$(A3M_PIPELINE_DATA) \
 			a3m-pipeline-data
 
-migrate: bootstrap  ## Same as make bootstrap.
-
-bootstrap:  ## Bootstrap a3m (new database).
-	docker-compose run --rm --no-deps --entrypoint /a3m/manage.py a3m migrate --noinput
-
+.PHONY: manage
 manage:  ## Run Django /manage.py on a3m, suppling <command> [options] as value to ARG, e.g., `make manage ARG=shell`
-	docker-compose run --rm --no-deps --entrypoint /a3m/manage.py a3m $(ARG)
+	$(call compose_run, \
+		--entrypoint /a3m/manage.py \
+		a3m \
+			$(ARG))
 
-migrations:  ## Make Django migrations.
-	docker-compose run --rm --user=$(CURRENT_UID) --entrypoint=/a3m/manage.py a3m makemigrations main fpr
+.PHONY: bootstrap
+bootstrap:  ## Bootstrap a3m (new database).
+	$(MAKE) manage ARG="migrate --noinput"
 
-reset-migrations:
-	@echo "Disabled! This is a temporary hack, uncomment and use carefully!"
-	exit 1
-	find a3m/main/migrations -name "*.py" -delete
-	find a3m/fpr/migrations -name "*.py" -delete
-	find a3m/ -name "*.pyc" -delete
-	docker-compose run --rm --user=$(CURRENT_UID) --entrypoint=/a3m/manage.py a3m makemigrations main fpr
-	git checkout -- a3m/main/migrations/0002_initial_data.py a3m/fpr/migrations/0002_initial_data.py
-	black a3m/main/migrations a3m/fpr/migrations
-	reorder-python-imports --exit-zero-even-if-changed a3m/main/migrations/0001_initial.py a3m/fpr/migrations/0001_initial.py
-	pyupgrade --py39-plus --exit-zero-even-if-changed a3m/main/migrations/0001_initial.py a3m/fpr/migrations/0001_initial.py
+.PHONY: makemigrations
+makemigrations:  ## Make Django migrations.
+	$(MAKE) manage ARG="makemigrations main fpr"
 
-logs:
-	docker-compose logs -f
+.PHONY: stop
+stop:  ## Stop services
+	docker-compose stop a3m
 
+.PHONY: restart
 restart:  ## Restart services
 	docker-compose restart a3m
 
-pip-compile:  # Compile pip requirements
-	pip-compile --output-file requirements.txt
-	pip-compile --output-file requirements-dev.txt --extra dev
+.PHONY: pip-compile
+pip-compile:  ## Compile pip requirements
+	$(call compose_run, \
+		--entrypoint=pip-compile \
+		a3m \
+			--output-file requirements.txt)
+	$(call compose_run, \
+		--entrypoint=pip-compile \
+		a3m \
+			--extra dev --output-file requirements-dev.txt)
 
-pip-upgrade:  # Upgrade pip requirements
-	pip-compile --upgrade --output-file requirements.txt
-	pip-compile --upgrade --output-file requirements-dev.txt --extra dev
+.PHONY: pip-upgrade
+pip-upgrade:  ## Upgrade pip requirements
+	$(call compose_run, \
+		--entrypoint=pip-compile \
+		a3m \
+			--upgrade --output-file requirements.txt)
+	$(call compose_run, \
+		--entrypoint=pip-compile \
+		a3m \
+			--extra dev --upgrade --output-file requirements-dev.txt)
 
-pip-sync:  # Sync virtualenv
-	pip-sync requirements-dev.txt
-
-pip-ensure:  # Compile, upgrade and install requirements
-	$(MAKE) pip-upgrade pip-sync
-	pip list --outdated
-
+.PHONY: db
 db:
-	sqlite3 $(CURDIR)/hack/compose-volume/db.sqlite
+	$(call compose_run, \
+		--entrypoint=sqlite3 \
+		a3m \
+			./hack/compose-volume/db.sqlite)
 
-flush: flush-db flush-shared-dir bootstrap restart  ## Delete ALL user data.
+.PHONY: flush
+flush: stop flush-db flush-shared-dir bootstrap restart  ## Delete ALL user data.
 
+.PHONY: flush-db
 flush-db:  ## Flush SQLite database.
-	docker-compose run --rm --no-deps --entrypoint sh a3m -c "rm -rf /home/a3m/.local/share/a3m/db.sqlite"
+	$(call compose_run, \
+		--entrypoint sh \
+		a3m \
+			-c "rm -rf /home/a3m/.local/share/a3m/db.sqlite")
 
+.PHONY: flush-shared-dir
 flush-shared-dir:  ## Flush shared directory including the database.
-	docker-compose run --rm --no-deps --entrypoint sh a3m -c "rm -rf /home/a3m/.local/share/a3m/share/"
+	$(call compose_run, \
+		--entrypoint sh \
+		a3m \
+			-c "rm -rf /home/a3m/.local/share/a3m/share/")
 
-amflow:  ## See workflow.
-	amflow edit --file=a3m/assets/workflow.json
+.PHONY: amflow
+amflow:  ## Display the workflow in amflow.
+	docker run \
+		--rm \
+		-p 2323:2323 \
+		-v $(PWD)/a3m/assets/workflow.json:/workflow.json \
+		artefactual/amflow:latest \
+			edit --file=/workflow.json
 
+.PHONY: protoc
 protoc:  ## Generate gRPC code.
-	python3 -m grpc_tools.protoc -I=. --python_out=. --grpc_python_out=. a3m/server/rpc/proto/a3m.proto
-	black $(CURDIR)/a3m/server/rpc/proto
+	$(call compose_run, \
+		--entrypoint python \
+		a3m \
+			-m grpc_tools.protoc -I=. --python_out=. --grpc_python_out=. a3m/server/rpc/proto/a3m.proto)
+	$(call compose_run, \
+		--entrypoint black \
+		a3m \
+			a3m/server/rpc/proto)
 
+.PHONY: help
 help:  ## Print this help message.
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
+.PHONY: publish
 publish: publish-clean  ## Publish to PyPI
 	pip install --upgrade twine wheel
 	python setup.py sdist
@@ -93,7 +157,16 @@ publish: publish-clean  ## Publish to PyPI
 	twine check dist/*
 	twine upload dist/* --repository-url https://upload.pypi.org/legacy/
 
+.PHONY: publish-clean
 publish-clean:
 	rm -rf a3m.egg-info/
 	rm -rf build/
 	rm -rf dist/
+
+.PHONY: tox
+tox: build  ## Run a toxenv.
+	$(call toxenvs,$(ARG))
+
+.PHONY: test
+test:  ## Run the tests with coverage.
+	$(MAKE) tox ARG="py"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,12 @@ services:
   a3m:
     build:
       context: "."
+      args:
+        USER_ID: ${USER_ID:-1000}
+        GROUP_ID: ${GROUP_ID:-1000}
+        PYTHON_VERSION: ${PYTHON_VERSION:-3.9}
+        REQUIREMENTS: ${REQUIREMENTS:-/a3m/requirements-dev.txt}
+        DJANGO_SETTINGS_MODULE: ${DJANGO_SETTINGS_MODULE:-a3m.settings.common}
     environment:
       A3M_PROMETHEUS_BIND_PORT: "7999"
       A3M_PROMETHEUS_BIND_ADDRESS: "0.0.0.0"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,9 +10,9 @@ ammcpc==0.1.3
     # via a3m (setup.py)
 appdirs==1.4.4
     # via a3m (setup.py)
-asgiref==3.4.1
+asgiref==3.5.0
     # via django
-astroid==2.9.2
+astroid==2.11.2
     # via pylint
 attrs==21.4.0
     # via
@@ -22,11 +22,11 @@ babel==2.9.1
     # via sphinx
 bagit==1.8.1
     # via a3m (setup.py)
-black==21.12b0
+black==22.3.0
     # via a3m (setup.py)
-boto3==1.20.27
+boto3==1.21.38
     # via a3m (setup.py)
-botocore==1.23.27
+botocore==1.24.38
     # via
     #   boto3
     #   s3transfer
@@ -34,11 +34,11 @@ certifi==2021.10.8
     # via requests
 cfgv==3.3.1
     # via pre-commit
-charset-normalizer==2.0.9
+charset-normalizer==2.0.12
     # via requests
 clamd==1.0.2
     # via a3m (setup.py)
-click==8.0.3
+click==8.1.2
     # via
     #   a3m (setup.py)
     #   black
@@ -47,17 +47,19 @@ colorama==0.4.4
     # via rich
 commonmark==0.9.1
     # via rich
-coverage[toml]==6.2
+coverage[toml]==6.3.2
     # via
     #   a3m (setup.py)
     #   pytest-cov
+dill==0.3.4
+    # via pylint
 distlib==0.3.4
     # via virtualenv
-django==3.2.11
+django==3.2.13
     # via a3m (setup.py)
 docutils==0.17.1
     # via sphinx
-filelock==3.4.2
+filelock==3.6.0
     # via
     #   tox
     #   virtualenv
@@ -65,23 +67,23 @@ flake8==4.0.1
     # via a3m (setup.py)
 future==0.18.2
     # via metsrw
-googleapis-common-protos==1.54.0
+googleapis-common-protos==1.56.0
     # via
     #   a3m (setup.py)
     #   grpcio-status
-grpcio==1.43.0
+grpcio==1.44.0
     # via
     #   a3m (setup.py)
     #   grpcio-reflection
     #   grpcio-status
     #   grpcio-tools
-grpcio-reflection==1.43.0
+grpcio-reflection==1.44.0
     # via a3m (setup.py)
-grpcio-status==1.43.0
+grpcio-status==1.44.0
     # via a3m (setup.py)
-grpcio-tools==1.43.0
+grpcio-tools==1.44.0
     # via a3m (setup.py)
-identify==2.4.1
+identify==2.4.12
     # via pre-commit
 idna==3.3
     # via
@@ -89,36 +91,38 @@ idna==3.3
     #   yarl
 imagesize==1.3.0
     # via sphinx
+importlib-metadata==4.11.3
+    # via sphinx
 iniconfig==1.1.1
     # via pytest
 isort==5.10.1
     # via pylint
-jinja2==3.0.3
+jinja2==3.1.1
     # via sphinx
-jmespath==0.10.0
+jmespath==1.0.0
     # via
     #   boto3
     #   botocore
-jsonschema==4.3.3
+jsonschema==4.4.0
     # via a3m (setup.py)
 lazy-object-proxy==1.7.1
     # via astroid
-lxml==4.7.1
+lxml==4.8.0
     # via
     #   a3m (setup.py)
     #   ammcpc
     #   metsrw
-markupsafe==2.0.1
+markupsafe==2.1.1
     # via jinja2
 mccabe==0.6.1
     # via
     #   flake8
     #   pylint
-metsrw==0.3.20
+metsrw==0.3.21
     # via a3m (setup.py)
-multidict==5.2.0
+multidict==6.0.2
     # via yarl
-mypy==0.930
+mypy==0.942
     # via a3m (setup.py)
 mypy-extensions==0.4.3
     # via
@@ -135,9 +139,9 @@ pathspec==0.9.0
     # via black
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.4.0
+pip-tools==6.6.0
     # via a3m (setup.py)
-platformdirs==2.4.1
+platformdirs==2.5.1
     # via
     #   black
     #   pylint
@@ -146,11 +150,11 @@ pluggy==1.0.0
     # via
     #   pytest
     #   tox
-pre-commit==2.16.0
+pre-commit==2.18.1
     # via a3m (setup.py)
-prometheus-client==0.12.0
+prometheus-client==0.14.1
     # via a3m (setup.py)
-protobuf==3.19.1
+protobuf==3.20.0
     # via
     #   googleapis-common-protos
     #   grpcio-reflection
@@ -166,17 +170,17 @@ pyflakes==2.4.0
     # via flake8
 pygfried==0.2.0
     # via a3m (setup.py)
-pygments==2.11.1
+pygments==2.11.2
     # via
     #   rich
     #   sphinx
-pylint==2.12.2
+pylint==2.13.5
     # via a3m (setup.py)
-pyparsing==3.0.6
+pyparsing==3.0.8
     # via packaging
-pyrsistent==0.18.0
+pyrsistent==0.18.1
     # via jsonschema
-pytest==6.2.5
+pytest==7.1.1
     # via
     #   a3m (setup.py)
     #   pytest-cov
@@ -186,11 +190,11 @@ pytest-cov==3.0.0
     # via a3m (setup.py)
 pytest-django==4.5.2
     # via a3m (setup.py)
-pytest-mock==3.6.1
+pytest-mock==3.7.0
     # via a3m (setup.py)
 python-dateutil==2.8.2
     # via botocore
-pytz==2021.3
+pytz==2022.1
     # via
     #   babel
     #   django
@@ -200,13 +204,13 @@ pyyaml==6.0
     #   vcrpy
 releases==1.6.3
     # via a3m (setup.py)
-requests==2.27.0
+requests==2.27.1
     # via
     #   a3m (setup.py)
     #   sphinx
 rich==10.16.2
     # via a3m (setup.py)
-s3transfer==0.5.0
+s3transfer==0.5.2
     # via boto3
 semantic-version==2.6.0
     # via releases
@@ -219,7 +223,7 @@ six==1.16.0
     #   virtualenv
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==4.3.2
+sphinx==4.5.0
     # via
     #   a3m (setup.py)
     #   releases
@@ -244,33 +248,33 @@ tenacity==8.0.1
 toml==0.10.2
     # via
     #   pre-commit
-    #   pylint
-    #   pytest
     #   tox
     #   vulture
-tomli==1.2.3
+tomli==2.0.1
     # via
     #   black
     #   coverage
     #   mypy
     #   pep517
-tox==3.24.5
+    #   pylint
+    #   pytest
+tox==3.25.0
     # via a3m (setup.py)
-typing-extensions==4.0.1
+typing-extensions==4.1.1
     # via
     #   astroid
     #   black
     #   mypy
     #   pylint
-unidecode==1.3.2
+unidecode==1.3.4
     # via a3m (setup.py)
-urllib3==1.26.7
+urllib3==1.26.9
     # via
     #   botocore
     #   requests
 vcrpy==4.1.1
     # via a3m (setup.py)
-virtualenv==20.13.0
+virtualenv==20.14.1
     # via
     #   pre-commit
     #   tox
@@ -278,12 +282,14 @@ vulture==2.3
     # via a3m (setup.py)
 wheel==0.37.1
     # via pip-tools
-wrapt==1.13.3
+wrapt==1.14.0
     # via
     #   astroid
     #   vcrpy
 yarl==1.7.2
     # via vcrpy
+zipp==3.8.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,84 +8,84 @@ ammcpc==0.1.3
     # via a3m (setup.py)
 appdirs==1.4.4
     # via a3m (setup.py)
-asgiref==3.4.1
+asgiref==3.5.0
     # via django
 attrs==21.4.0
     # via jsonschema
 bagit==1.8.1
     # via a3m (setup.py)
-boto3==1.20.27
+boto3==1.21.38
     # via a3m (setup.py)
-botocore==1.23.27
+botocore==1.24.38
     # via
     #   boto3
     #   s3transfer
 certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.9
+charset-normalizer==2.0.12
     # via requests
 clamd==1.0.2
     # via a3m (setup.py)
-click==8.0.3
+click==8.1.2
     # via a3m (setup.py)
 colorama==0.4.4
     # via rich
 commonmark==0.9.1
     # via rich
-django==3.2.11
+django==3.2.13
     # via a3m (setup.py)
 future==0.18.2
     # via metsrw
-googleapis-common-protos==1.54.0
+googleapis-common-protos==1.56.0
     # via
     #   a3m (setup.py)
     #   grpcio-status
-grpcio==1.43.0
+grpcio==1.44.0
     # via
     #   a3m (setup.py)
     #   grpcio-reflection
     #   grpcio-status
-grpcio-reflection==1.43.0
+grpcio-reflection==1.44.0
     # via a3m (setup.py)
-grpcio-status==1.43.0
+grpcio-status==1.44.0
     # via a3m (setup.py)
 idna==3.3
     # via requests
-jmespath==0.10.0
+jmespath==1.0.0
     # via
     #   boto3
     #   botocore
-jsonschema==4.3.3
+jsonschema==4.4.0
     # via a3m (setup.py)
-lxml==4.7.1
+lxml==4.8.0
     # via
     #   a3m (setup.py)
     #   ammcpc
     #   metsrw
-metsrw==0.3.20
+metsrw==0.3.21
     # via a3m (setup.py)
-prometheus-client==0.12.0
+prometheus-client==0.14.1
     # via a3m (setup.py)
-protobuf==3.19.1
+protobuf==3.20.0
     # via
     #   googleapis-common-protos
     #   grpcio-reflection
     #   grpcio-status
 pygfried==0.2.0
     # via a3m (setup.py)
-pygments==2.11.1
+pygments==2.11.2
     # via rich
-pyrsistent==0.18.0
+pyrsistent==0.18.1
     # via jsonschema
 python-dateutil==2.8.2
     # via botocore
-pytz==2021.3
+pytz==2022.1
     # via django
-requests==2.27.0
+requests==2.27.1
     # via a3m (setup.py)
 rich==10.16.2
     # via a3m (setup.py)
-s3transfer==0.5.0
+s3transfer==0.5.2
     # via boto3
 six==1.16.0
     # via
@@ -96,9 +96,9 @@ sqlparse==0.4.2
     # via django
 tenacity==8.0.1
     # via a3m (setup.py)
-unidecode==1.3.2
+unidecode==1.3.4
     # via a3m (setup.py)
-urllib3==1.26.7
+urllib3==1.26.9
     # via
     #   botocore
     #   requests


### PR DESCRIPTION
This updates the `Makefile` rules and the GitHub Actions `tests` workflow to rely on the Compose environment.

The most relevant changes are:

* The `USER_ID` and `GROUP_ID` of the `a3m` user created in the `Dockerfile` are passed as build parameters so the host user has read and write permissions on files created inside the container on the mounted volume.
* The Python requirements have been upgraded and are installed in an isolated virtual environment and owned by the `a3m` user.
* Unit tests can be run with `make test`. `make help` can still be used to see the rest of the available rules.
* `tox` caches its own requirements in the `.tox` directory in the repository.

I tested this with Podman 3.4 and Podman Compose 1.0.3 on Ubuntu 20.04 and AIPs are successfully created but they're stored in `~/.local/share/containers/storage/volumes/a3m-pipeline-data/_data/share/completed/` and not at `hack/compose-volume` as I expected.

Connected to https://github.com/artefactual-labs/a3m/issues/247