### PR TITLE
Pre-create CONFIG_DIR/a3m/share

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ RUN freshclam --quiet
 RUN set -ex \
 	&& groupadd --gid ${GROUP_ID} --system a3m \
 	&& useradd --uid ${USER_ID} --gid ${GROUP_ID} --create-home --home-dir /home/a3m --system a3m \
-	&& mkdir -p /home/a3m/.local/share/a3m \
+	&& mkdir -p /home/a3m/.local/share/a3m/share \
 	&& chown -R a3m:a3m /home/a3m/.local
 
 


### PR DESCRIPTION
Make the share directory available in the Docker image. If the user mounts a
volume, it will leave the original permissions.