### PR TITLE
Add choice for format identification of metadata files

### DIFF
--- a/a3m/assets/workflow.json
+++ b/a3m/assets/workflow.json
@@ -107,7 +107,7 @@
                 ]
             },
             "description": {
-                "en": "Do you want to perform file format identification?"
+                "en": "Do you want to perform file format identification (submission documentation)?"
             },
             "exit_codes": {},
             "fallback_job_status": "Failed",
@@ -1874,11 +1874,34 @@
             "exit_codes": {
                 "0": {
                     "job_status": "Completed successfully",
-                    "link_id": "b2444a6e-c626-4487-9abc-1556dd89a8ae"
+                    "link_id": "c8bf3e7e-d8d1-4fc0-a1f1-3ff0be59e950"
                 }
             },
             "fallback_job_status": "Failed",
             "fallback_link_id": "b2ef06b9-bca4-49da-bc5c-866d7b3c4bb1",
+            "group": {
+                "en": "Process metadata directory",
+                "es": "Procesar directorio de metadatos",
+                "pt_BR": "Processar diretório de metadados",
+                "sv": "Bearbeta metadatamapp"
+            }
+        },
+        "c8bf3e7e-d8d1-4fc0-a1f1-3ff0be59e950":{
+            "config": {
+                "@manager": "linkTaskManagerChoice",
+                "config_attr": "identify_submission_and_metadata",
+                "default": true,
+                "choices": [
+                    {"value": true, "link_id": "b2444a6e-c626-4487-9abc-1556dd89a8ae"},
+                    {"value": false, "link_id": "04493ab2-6cad-400d-8832-06941f121a96"}
+                ]
+            },
+            "description": {
+                "en": "Do you want to perform file format identification (metadata)?"
+            },
+            "exit_codes": {},
+            "fallback_job_status": "Failed",
+            "fallback_link_id": null,
             "group": {
                 "en": "Process metadata directory",
                 "es": "Procesar directorio de metadatos",

--- a/proto/a3m/api/transferservice/v1beta1/request_response.proto
+++ b/proto/a3m/api/transferservice/v1beta1/request_response.proto
@@ -80,6 +80,10 @@ message ProcessingConfig {
 	bool extract_packages = 5;
 	bool delete_packages_after_extraction = 6;
 	bool identify_transfer = 7;
+	// identify_submission_and_metadata represents a single configuration
+	// attribute that controls two separate file format identification jobs
+	// in the workflow: one for objects/submissionDocumentation and one
+	// for objects/metadata
 	bool identify_submission_and_metadata = 8;
 	bool identify_before_normalization = 9;
 	bool normalize = 10;


### PR DESCRIPTION
This adds a new job to the workflow to choose if file format identification should be performed on the `objects/metadata` directory. The choice can be controlled using the existing `identify_submission_and_metadata` boolean field of the processing configuration.