### PR TITLE
Reduce probability of transaction errors

### DIFF
--- a/a3m/archivematicaFunctions.py
+++ b/a3m/archivematicaFunctions.py
@@ -21,6 +21,7 @@ import collections
 import hashlib
 import os
 import re
+from itertools import zip_longest
 from uuid import uuid4
 
 from a3m.namespaces import NSMAP
@@ -227,3 +228,12 @@ def find_transfer_path_from_ingest(transfer_path, shared_path):
         return path
 
     raise Exception("Transfer directory not physically found")
+
+
+def chunk_iterable(iterable, chunk_size=10, fillvalue=None):
+    """Collect data into fixed-length chunks or blocks.
+    >>> list(chunk_iterable('ABCDEFG', 3, 'x'))
+    [('A', 'B', 'C'), ('D', 'E', 'F'), ('G', 'x', 'x')]
+    """
+    args = [iter(iterable)] * chunk_size
+    return zip_longest(fillvalue=fillvalue, *args)  # type: ignore

--- a/a3m/assets/workflow.json
+++ b/a3m/assets/workflow.json
@@ -783,12 +783,12 @@
         },
         "2a62f025-83ec-4f23-adb4-11d5da7ad8c2": {
             "config": {
-                "@manager": "linkTaskManagerFiles",
-                "arguments": "--filePath \"%relativeLocation%\" --fileUUID \"%fileUUID%\" --eventIdentifierUUID \"%taskUUID%\" --date \"%date%\"",
+                "@manager": "linkTaskManagerDirectories",
+                "arguments": "--sipUUID \"%SIPUUID%\" --sipDirectory \"%SIPDirectory%\" --eventIdentifierUUID \"%taskUUID%\" --date \"%date%\" --filterSubdir \"objects/submissionDocumentation\"",
                 "execute": "update_size_and_checksum",
                 "filter_file_end": null,
                 "filter_file_start": null,
-                "filter_subdir": "objects/submissionDocumentation",
+                "filter_subdir": null,
                 "stderr_file": null,
                 "stdout_file": null
             },
@@ -921,12 +921,12 @@
         },
         "370aca94-65ab-4f2a-9d7d-294a62c8b7ba": {
             "config": {
-                "@manager": "linkTaskManagerFiles",
-                "arguments": "--filePath \"%relativeLocation%\" --fileUUID \"%fileUUID%\" --eventIdentifierUUID \"%taskUUID%\" --date \"%date%\"",
+                "@manager": "linkTaskManagerDirectories",
+                "arguments": "--transferUUID \"%TransferUUID%\" --sipDirectory \"%SIPDirectory%\" --eventIdentifierUUID \"%taskUUID%\" --date \"%date%\" --filterSubdir \"objects\"",
                 "execute": "update_size_and_checksum",
                 "filter_file_end": null,
                 "filter_file_start": null,
-                "filter_subdir": "objects",
+                "filter_subdir": null,
                 "stderr_file": null,
                 "stdout_file": null
             },
@@ -1159,12 +1159,12 @@
         },
         "4edfe7e4-82ff-4c0a-ba5f-29f1ee14e17a": {
             "config": {
-                "@manager": "linkTaskManagerFiles",
-                "arguments": "--sipUUID \"%SIPUUID%\" --sipDirectory \"%SIPDirectory%\" --filePath \"%relativeLocation%\" --fileUUID \"%fileUUID%\" --eventIdentifierUUID \"%taskUUID%\" --date \"%date%\" --use \"submissionDocumentation\"",
+                "@manager": "linkTaskManagerDirectories",
+                "arguments": "--sipUUID \"%SIPUUID%\" --sipDirectory \"%SIPDirectory%\" --eventIdentifierUUID \"%taskUUID%\" --date \"%date%\" --use \"submissionDocumentation\" --filterSubdir \"objects/submissionDocumentation\"",
                 "execute": "assign_file_uuids",
                 "filter_file_end": null,
                 "filter_file_start": null,
-                "filter_subdir": "objects/submissionDocumentation",
+                "filter_subdir": null,
                 "stderr_file": "%SIPLogsDirectory%FileUUIDsError.log",
                 "stdout_file": "%SIPLogsDirectory%FileUUIDs.log"
             },
@@ -2088,15 +2088,15 @@
         },
         "9e9b522a-77ab-4c17-ab08-5a4256f49d59": {
             "config": {
-                "@manager": "linkTaskManagerFiles",
-                "arguments": "--sipUUID \"%SIPUUID%\" --sipDirectory \"%SIPDirectory%\" --filePath \"%relativeLocation%\" --fileUUID \"%fileUUID%\" --eventIdentifierUUID \"%taskUUID%\" --date \"%date%\" --use \"preservation\"",
+                "@manager": "linkTaskManagerDirectories",
+                "arguments": "--sipUUID \"%SIPUUID%\" --sipDirectory \"%SIPDirectory%\" --eventIdentifierUUID \"%taskUUID%\" --date \"%date%\" --use \"preservation\" --filterSubdir \"objects/manualNormalization/preservation\"",
                 "execute": "assign_file_uuids",
                 "filter_file_end": null,
                 "filter_file_start": null,
-                "filter_subdir": "objects/manualNormalization/preservation",
+                "filter_subdir": null,
                 "stderr_file": null,
                 "stdout_file": null
-            },
+            },            
             "description": {
                 "en": "Assign UUIDs to manual normalized preservation files",
                 "es": "Asignar UUIDs a los ficheros preservados manualmente",
@@ -2352,12 +2352,12 @@
         },
         "b6b0fe37-aa26-40bd-8be8-d3acebf3ccf8": {
             "config": {
-                "@manager": "linkTaskManagerFiles",
-                "arguments": "--filePath \"%relativeLocation%\" --fileUUID \"%fileUUID%\" --eventIdentifierUUID \"%taskUUID%\" --date \"%date%\"",
+                "@manager": "linkTaskManagerDirectories",
+                "arguments": "--sipUUID \"%SIPUUID%\" --sipDirectory \"%SIPDirectory%\" --eventIdentifierUUID \"%taskUUID%\" --date \"%date%\" --filterSubdir \"objects/metadata\"",
                 "execute": "update_size_and_checksum",
                 "filter_file_end": null,
                 "filter_file_start": null,
-                "filter_subdir": "objects/metadata",
+                "filter_subdir": null,
                 "stderr_file": null,
                 "stdout_file": null
             },
@@ -2782,12 +2782,12 @@
         },
         "dc144ff4-ad74-4a6e-ac15-b0beedcaf662": {
             "config": {
-                "@manager": "linkTaskManagerFiles",
-                "arguments": "--transferUUID \"%TransferUUID%\" --sipDirectory \"%SIPDirectory%\" --filePath \"%relativeLocation%\" --fileUUID \"%fileUUID%\" --eventIdentifierUUID \"%taskUUID%\" --date \"%date%\"",
+                "@manager": "linkTaskManagerDirectories",
+                "arguments": "--transferUUID \"%TransferUUID%\" --sipDirectory \"%SIPDirectory%\" --eventIdentifierUUID \"%taskUUID%\" --date \"%date%\" --filterSubdir \"objects\"",
                 "execute": "assign_file_uuids",
                 "filter_file_end": null,
                 "filter_file_start": null,
-                "filter_subdir": "objects",
+                "filter_subdir": null,
                 "stderr_file": "%SIPLogsDirectory%FileUUIDsError.log",
                 "stdout_file": "%SIPLogsDirectory%FileUUIDs.log"
             },
@@ -2818,12 +2818,12 @@
         },
         "dc9d4991-aefa-4d7e-b7b5-84e3c4336e74": {
             "config": {
-                "@manager": "linkTaskManagerFiles",
-                "arguments": "--sipUUID \"%SIPUUID%\" --sipDirectory \"%SIPDirectory%\" --filePath \"%relativeLocation%\" --fileUUID \"%fileUUID%\" --eventIdentifierUUID \"%taskUUID%\" --date \"%date%\" --use \"metadata\" --disable-update-filegrpuse",
+                "@manager": "linkTaskManagerDirectories",
+                "arguments": "--sipUUID \"%SIPUUID%\" --sipDirectory \"%SIPDirectory%\" --eventIdentifierUUID \"%taskUUID%\" --date \"%date%\" --use \"metadata\" --filterSubdir \"objects/metadata\" --disable-update-filegrpuse",
                 "execute": "assign_file_uuids",
                 "filter_file_end": null,
                 "filter_file_start": null,
-                "filter_subdir": "objects/metadata",
+                "filter_subdir": null,
                 "stderr_file": "%SIPLogsDirectory%FileUUIDsError.log",
                 "stdout_file": "%SIPLogsDirectory%FileUUIDs.log"
             },
@@ -2914,12 +2914,12 @@
         },
         "e76aec15-5dfa-4b14-9405-735863e3a6fa": {
             "config": {
-                "@manager": "linkTaskManagerFiles",
-                "arguments": "--filePath \"%relativeLocation%\" --fileUUID \"%fileUUID%\" --eventIdentifierUUID \"%taskUUID%\" --date \"%date%\"",
+                "@manager": "linkTaskManagerDirectories",
+                "arguments": "--sipUUID \"%SIPUUID%\" --sipDirectory \"%SIPDirectory%\" --eventIdentifierUUID \"%taskUUID%\" --date \"%date%\" --filterSubdir \"objects/manualNormalization/preservation\"",
                 "execute": "update_size_and_checksum",
                 "filter_file_end": null,
                 "filter_file_start": null,
-                "filter_subdir": "objects/manualNormalization/preservation",
+                "filter_subdir": null,
                 "stderr_file": null,
                 "stdout_file": null
             },

--- a/a3m/client/clientScripts/update_size_and_checksum.py
+++ b/a3m/client/clientScripts/update_size_and_checksum.py
@@ -16,25 +16,104 @@
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 import argparse
 import logging
+import os
 import uuid
 
 from django.db import transaction
 
+from a3m.archivematicaFunctions import chunk_iterable
 from a3m.fileOperations import updateSizeAndChecksum
 from a3m.main.models import File
 
 
 logger = logging.getLogger(__name__)
 
+SIP_REPLACEMENT_PATH_STRING = r"%SIPDirectory%"
+TRANSFER_REPLACEMENT_PATH_STRING = r"%transferDirectory%"
 
-def main(job, file_uuid, file_path, date, event_uuid):
-    try:
-        File.objects.get(uuid=file_uuid)
-    except File.DoesNotExist:
-        logger.exception("File with UUID %s cannot be found.", file_uuid)
-        return 1
 
-    updateSizeAndChecksum(file_uuid, file_path, date, event_uuid)
+def _filter_queryset_by_subdir(queryset, replacement_path_string, filter_subdir):
+    """Filter queryset by filter_subdir."""
+    filter_path = "".join([replacement_path_string, filter_subdir])
+    return queryset.filter(currentlocation__startswith=filter_path)
+
+
+def get_transfer_file_queryset(transfer_uuid, filter_subdir):
+    """Return Queryset of files in this transfer."""
+    files = File.objects.filter(transfer=transfer_uuid)
+    if filter_subdir:
+        files = _filter_queryset_by_subdir(
+            files, TRANSFER_REPLACEMENT_PATH_STRING, filter_subdir
+        )
+    return files
+
+
+def get_sip_file_queryset(sip_uuid, filter_subdir):
+    """Return Queryset of files in this SIP."""
+    files = File.objects.filter(sip=sip_uuid)
+    if filter_subdir:
+        files = _filter_queryset_by_subdir(
+            files, SIP_REPLACEMENT_PATH_STRING, filter_subdir
+        )
+    return files
+
+
+def update_size_and_checksum_for_file(
+    job,
+    file_,
+    sip_directory,
+    transfer_uuid,
+    date,
+    event_uuid,
+):
+    """Update size and checksum for file in database.
+
+    If file is from Archivematica AIP transfer, try to extract and use
+    the size, checksum, and checksum type values from the METS.
+    """
+    kw = {}
+    if transfer_uuid:
+        file_path = file_.currentlocation.replace(
+            TRANSFER_REPLACEMENT_PATH_STRING, sip_directory
+        )
+    else:
+        file_path = file_.currentlocation.replace(
+            SIP_REPLACEMENT_PATH_STRING, sip_directory
+        )
+
+    if not os.path.exists(file_path):
+        return
+
+    job.print_output(f"Updating file size and checksum for file {file_.uuid}")
+    updateSizeAndChecksum(file_.uuid, file_path, date, event_uuid, **kw)
+
+
+def update_files(
+    job,
+    files,
+    sip_directory,
+    transfer_uuid,
+    date,
+    event_uuid,
+):
+    """Update file sizes and checksums for each file in list.
+
+    We open a database transaction for each chunk of 10 files, in an
+    attempt to balance performance with reasonable transaction lengths.
+    """
+    for file_chunk in chunk_iterable(files):
+        with transaction.atomic():
+            for file_ in file_chunk:
+                if not file_:
+                    continue
+                update_size_and_checksum_for_file(
+                    job,
+                    file_,
+                    sip_directory,
+                    transfer_uuid,
+                    date,
+                    event_uuid,
+                )
 
     return 0
 
@@ -42,30 +121,42 @@ def main(job, file_uuid, file_path, date, event_uuid):
 def call(jobs):
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "-i", "--fileUUID", type=lambda x: str(uuid.UUID(x)), dest="file_uuid"
+        "-s", "--sipDirectory", action="store", dest="sip_directory", default=""
     )
-    parser.add_argument(
-        "-p", "--filePath", action="store", dest="file_path", default=""
-    )
+    parser.add_argument("-S", "--sipUUID", type=uuid.UUID, dest="sip_uuid")
+    parser.add_argument("-T", "--transferUUID", type=uuid.UUID, dest="transfer_uuid")
     parser.add_argument("-d", "--date", action="store", dest="date", default="")
+    parser.add_argument(
+        "--filterSubdir", action="store", dest="filter_subdir", default=None
+    )
     parser.add_argument(
         "-u",
         "--eventIdentifierUUID",
-        type=lambda x: str(uuid.UUID(x)),
+        type=uuid.UUID,
         dest="event_uuid",
     )
 
-    with transaction.atomic():
-        for job in jobs:
-            with job.JobContext(logger=logger):
-                args = parser.parse_args(job.args[1:])
+    for job in jobs:
+        with job.JobContext(logger=logger):
+            args = parser.parse_args(job.args[1:])
 
-                job.set_status(
-                    main(
-                        job,
-                        args.file_uuid,
-                        args.file_path,
-                        args.date,
-                        args.event_uuid,
-                    )
+            TRANSFER_SIP_UUIDS = [args.sip_uuid, args.transfer_uuid]
+            if all(TRANSFER_SIP_UUIDS) or not any(TRANSFER_SIP_UUIDS):
+                job.print_error("SIP exclusive-or Transfer UUID must be defined")
+                job.set_status(2)
+                return
+
+            files = get_transfer_file_queryset(args.transfer_uuid, args.filter_subdir)
+            if args.sip_uuid:
+                files = get_sip_file_queryset(args.sip_uuid, args.filter_subdir)
+
+            job.set_status(
+                update_files(
+                    job,
+                    files,
+                    args.sip_directory,
+                    args.transfer_uuid,
+                    args.date,
+                    args.event_uuid,
                 )
+            )

--- a/a3m/client/clientScripts/update_size_and_checksum.py
+++ b/a3m/client/clientScripts/update_size_and_checksum.py
@@ -21,7 +21,7 @@ import uuid
 
 from django.db import transaction
 
-from a3m.archivematicaFunctions import chunk_iterable
+from a3m.fileOperations import get_size_and_checksum
 from a3m.fileOperations import updateSizeAndChecksum
 from a3m.main.models import File
 
@@ -58,20 +58,8 @@ def get_sip_file_queryset(sip_uuid, filter_subdir):
     return files
 
 
-def update_size_and_checksum_for_file(
-    job,
-    file_,
-    sip_directory,
-    transfer_uuid,
-    date,
-    event_uuid,
-):
-    """Update size and checksum for file in database.
-
-    If file is from Archivematica AIP transfer, try to extract and use
-    the size, checksum, and checksum type values from the METS.
-    """
-    kw = {}
+def get_size_and_checksum_for_file(file_, sip_directory, transfer_uuid):
+    """Get size and checksum for a file."""
     if transfer_uuid:
         file_path = file_.currentlocation.replace(
             TRANSFER_REPLACEMENT_PATH_STRING, sip_directory
@@ -82,40 +70,16 @@ def update_size_and_checksum_for_file(
         )
 
     if not os.path.exists(file_path):
-        return
+        return {}
 
-    job.print_output(f"Updating file size and checksum for file {file_.uuid}")
-    updateSizeAndChecksum(file_.uuid, file_path, date, event_uuid, **kw)
+    fileSize, checksum, checksumType = get_size_and_checksum(file_path)
 
-
-def update_files(
-    job,
-    files,
-    sip_directory,
-    transfer_uuid,
-    date,
-    event_uuid,
-):
-    """Update file sizes and checksums for each file in list.
-
-    We open a database transaction for each chunk of 10 files, in an
-    attempt to balance performance with reasonable transaction lengths.
-    """
-    for file_chunk in chunk_iterable(files):
-        with transaction.atomic():
-            for file_ in file_chunk:
-                if not file_:
-                    continue
-                update_size_and_checksum_for_file(
-                    job,
-                    file_,
-                    sip_directory,
-                    transfer_uuid,
-                    date,
-                    event_uuid,
-                )
-
-    return 0
+    return {
+        "filePath": file_path,
+        "fileSize": fileSize,
+        "checksum": checksum,
+        "checksumType": checksumType,
+    }
 
 
 def call(jobs):
@@ -136,6 +100,8 @@ def call(jobs):
         dest="event_uuid",
     )
 
+    state = []
+
     for job in jobs:
         with job.JobContext(logger=logger):
             args = parser.parse_args(job.args[1:])
@@ -144,19 +110,26 @@ def call(jobs):
             if all(TRANSFER_SIP_UUIDS) or not any(TRANSFER_SIP_UUIDS):
                 job.print_error("SIP exclusive-or Transfer UUID must be defined")
                 job.set_status(2)
-                return
+                continue
 
             files = get_transfer_file_queryset(args.transfer_uuid, args.filter_subdir)
             if args.sip_uuid:
                 files = get_sip_file_queryset(args.sip_uuid, args.filter_subdir)
 
-            job.set_status(
-                update_files(
-                    job,
-                    files,
-                    args.sip_directory,
-                    args.transfer_uuid,
-                    args.date,
-                    args.event_uuid,
+            for file_ in files:
+                if not file_:
+                    continue
+                file_info = get_size_and_checksum_for_file(
+                    file_, args.sip_directory, args.transfer_uuid
                 )
+                if file_info:
+                    state.append((file_.uuid, file_info, args))
+
+            job.set_status(0)
+
+    with transaction.atomic():
+        for file_uuid, file_info, args in state:
+            file_path = file_info.pop("filePath")
+            updateSizeAndChecksum(
+                file_uuid, file_path, args.date, args.event_uuid, **file_info
             )

--- a/a3m/fileOperations.py
+++ b/a3m/fileOperations.py
@@ -28,6 +28,17 @@ from a3m.main.models import File
 from a3m.main.models import Transfer
 
 
+def get_size_and_checksum(file_path, file_size=None, checksum=None, checksum_type=None):
+    if not file_size:
+        file_size = os.path.getsize(file_path)
+    if not checksum_type:
+        checksum_type = django_settings.DEFAULT_CHECKSUM_ALGORITHM
+    if not checksum:
+        checksum = get_file_checksum(file_path, checksum_type)
+
+    return (file_size, checksum, checksum_type)
+
+
 def updateSizeAndChecksum(
     fileUUID,
     filePath,
@@ -45,12 +56,12 @@ def updateSizeAndChecksum(
     Finally, insert the corresponding Event. This behavior can be cancelled
     using the boolean keyword 'add_event'.
     """
-    if not fileSize:
-        fileSize = os.path.getsize(filePath)
-    if not checksumType:
-        checksumType = django_settings.DEFAULT_CHECKSUM_ALGORITHM
-    if not checksum:
-        checksum = get_file_checksum(filePath, checksumType)
+    fileSize, checksum, checksumType = get_size_and_checksum(
+        file_path=filePath,
+        file_size=fileSize,
+        checksum=checksum,
+        checksum_type=checksumType,
+    )
 
     File.objects.filter(uuid=fileUUID).update(
         size=fileSize, checksum=checksum, checksumtype=checksumType

--- a/a3m/main/__init__.py
+++ b/a3m/main/__init__.py
@@ -4,7 +4,7 @@ from django.db.backends.signals import connection_created
 def activate_wal_mode(sender, connection, **kwargs):
     if connection.vendor == "sqlite":
         cursor = connection.cursor()
-        cursor.execute("PRAGMA journal_mode=WAL;")
+        cursor.execute("PRAGMA journal_mode=WAL")
 
 
 connection_created.connect(activate_wal_mode)

--- a/a3m/settings/common.py
+++ b/a3m/settings/common.py
@@ -278,11 +278,12 @@ DEBUG = config.get("debug")
 if DEBUG:
     LOGGING["formatters"]["detailed"][
         "format"
-    ] = "%(levelname)-8s %(threadName)s <%(asctime)s> %(module)s:%(funcName)s:%(lineno)d: %(message)s"
+    ] = "%(levelname)-8s <%(process)d:%(threadName)s> <%(asctime)s> %(module)s:%(funcName)s:%(lineno)d: %(message)s"
     LOGGING["handlers"]["console"]["level"] = "DEBUG"
     LOGGING["root"]["level"] = "DEBUG"
     LOGGING["loggers"] = {
         "a3m": {"level": "DEBUG"},
+        # Use "DEBUG" to log database queries.
         "django.db.backends": {"level": "WARNING"},
     }
 


### PR DESCRIPTION
Refactor update_size_and_checksum and assign_file_uuids to run once
per transfer/SIP instead of per file.

Adapted from https://github.com/artefactual/archivematica/pull/1748.

---

Optimize transaction in checksums and sizes job 

Adapted from https://github.com/artefactual/archivematica/pull/1820.

---

Optimize transactions in characterize files job

Do a transaction per file, get rules and run characterization commands
storing the output in memory before starting the transaction. During the
transaction, get rules again and fail the task if they changed or write
them to the DB if they didn't change.

---

- Remove unneeded semicolon
- Fix CheckCloseConnectionsHandler
- Log PID in debug mode

---

Save all DB tasks before jobs submit

Save all tasks in the DB before submitting the batched jobs to the
thread pool. This reduces the probability of having multiple writers
at the same time over the DB and prevents some transaction issues
using SQLite.