### PR TITLE
Migrate from Buf remote generation alpha to v1

### DIFF
--- a/a3m/api/transferservice/v1beta1/request_response_pb2.py
+++ b/a3m/api/transferservice/v1beta1/request_response_pb2.py
@@ -18,40 +18,41 @@ DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
     b'\n6a3m/api/transferservice/v1beta1/request_response.proto\x12\x1f\x61\x33m.api.transferservice.v1beta1\x1a\x1fgoogle/protobuf/timestamp.proto"\x80\x01\n\rSubmitRequest\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12\x10\n\x03url\x18\x02 \x01(\tR\x03url\x12I\n\x06\x63onfig\x18\x03 \x01(\x0b\x32\x31.a3m.api.transferservice.v1beta1.ProcessingConfigR\x06\x63onfig" \n\x0eSubmitResponse\x12\x0e\n\x02id\x18\x01 \x01(\tR\x02id"\x1d\n\x0bReadRequest\x12\x0e\n\x02id\x18\x01 \x01(\tR\x02id"\xa2\x01\n\x0cReadResponse\x12\x46\n\x06status\x18\x01 \x01(\x0e\x32..a3m.api.transferservice.v1beta1.PackageStatusR\x06status\x12\x10\n\x03job\x18\x02 \x01(\tR\x03job\x12\x38\n\x04jobs\x18\x03 \x03(\x0b\x32$.a3m.api.transferservice.v1beta1.JobR\x04jobs")\n\x10ListTasksRequest\x12\x15\n\x06job_id\x18\x01 \x01(\tR\x05jobId"P\n\x11ListTasksResponse\x12;\n\x05tasks\x18\x01 \x03(\x0b\x32%.a3m.api.transferservice.v1beta1.TaskR\x05tasks"\x0e\n\x0c\x45mptyRequest"\x0f\n\rEmptyResponse"\xb9\x02\n\x03Job\x12\x0e\n\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n\x04name\x18\x02 \x01(\tR\x04name\x12\x14\n\x05group\x18\x03 \x01(\tR\x05group\x12\x17\n\x07link_id\x18\x04 \x01(\tR\x06linkId\x12\x43\n\x06status\x18\x05 \x01(\x0e\x32+.a3m.api.transferservice.v1beta1.Job.StatusR\x06status\x12\x39\n\nstart_time\x18\x06 \x01(\x0b\x32\x1a.google.protobuf.TimestampR\tstartTime"_\n\x06Status\x12\x16\n\x12STATUS_UNSPECIFIED\x10\x00\x12\x13\n\x0fSTATUS_COMPLETE\x10\x01\x12\x15\n\x11STATUS_PROCESSING\x10\x02\x12\x11\n\rSTATUS_FAILED\x10\x03"\xc6\x02\n\x04Task\x12\x0e\n\x02id\x18\x01 \x01(\tR\x02id\x12\x17\n\x07\x66ile_id\x18\x02 \x01(\tR\x06\x66ileId\x12\x1b\n\texit_code\x18\x03 \x01(\x05R\x08\x65xitCode\x12\x1a\n\x08\x66ilename\x18\x04 \x01(\tR\x08\x66ilename\x12\x1c\n\texecution\x18\x05 \x01(\tR\texecution\x12\x1c\n\targuments\x18\x06 \x01(\tR\targuments\x12\x16\n\x06stdout\x18\x07 \x01(\tR\x06stdout\x12\x16\n\x06stderr\x18\x08 \x01(\tR\x06stderr\x12\x39\n\nstart_time\x18\t \x01(\x0b\x32\x1a.google.protobuf.TimestampR\tstartTime\x12\x35\n\x08\x65nd_time\x18\n \x01(\x0b\x32\x1a.google.protobuf.TimestampR\x07\x65ndTime"\xcc\n\n\x10ProcessingConfig\x12=\n\x1b\x61ssign_uuids_to_directories\x18\x01 \x01(\x08R\x18\x61ssignUuidsToDirectories\x12)\n\x10\x65xamine_contents\x18\x02 \x01(\x08R\x0f\x65xamineContents\x12K\n"generate_transfer_structure_report\x18\x03 \x01(\x08R\x1fgenerateTransferStructureReport\x12<\n\x1a\x64ocument_empty_directories\x18\x04 \x01(\x08R\x18\x64ocumentEmptyDirectories\x12)\n\x10\x65xtract_packages\x18\x05 \x01(\x08R\x0f\x65xtractPackages\x12G\n delete_packages_after_extraction\x18\x06 \x01(\x08R\x1d\x64\x65letePackagesAfterExtraction\x12+\n\x11identify_transfer\x18\x07 \x01(\x08R\x10identifyTransfer\x12G\n identify_submission_and_metadata\x18\x08 \x01(\x08R\x1didentifySubmissionAndMetadata\x12\x42\n\x1didentify_before_normalization\x18\t \x01(\x08R\x1bidentifyBeforeNormalization\x12\x1c\n\tnormalize\x18\n \x01(\x08R\tnormalize\x12)\n\x10transcribe_files\x18\x0b \x01(\x08R\x0ftranscribeFiles\x12J\n"perform_policy_checks_on_originals\x18\x0c \x01(\x08R\x1eperformPolicyChecksOnOriginals\x12g\n1perform_policy_checks_on_preservation_derivatives\x18\r \x01(\x08R,performPolicyChecksOnPreservationDerivatives\x12\x32\n\x15\x61ip_compression_level\x18\x0e \x01(\x05R\x13\x61ipCompressionLevel\x12\x85\x01\n\x19\x61ip_compression_algorithm\x18\x0f \x01(\x0e\x32I.a3m.api.transferservice.v1beta1.ProcessingConfig.AIPCompressionAlgorithmR\x17\x61ipCompressionAlgorithm"\xda\x02\n\x17\x41IPCompressionAlgorithm\x12)\n%AIP_COMPRESSION_ALGORITHM_UNSPECIFIED\x10\x00\x12*\n&AIP_COMPRESSION_ALGORITHM_UNCOMPRESSED\x10\x01\x12!\n\x1d\x41IP_COMPRESSION_ALGORITHM_TAR\x10\x02\x12\'\n#AIP_COMPRESSION_ALGORITHM_TAR_BZIP2\x10\x03\x12&\n"AIP_COMPRESSION_ALGORITHM_TAR_GZIP\x10\x04\x12%\n!AIP_COMPRESSION_ALGORITHM_S7_COPY\x10\x05\x12&\n"AIP_COMPRESSION_ALGORITHM_S7_BZIP2\x10\x06\x12%\n!AIP_COMPRESSION_ALGORITHM_S7_LZMA\x10\x07*\xa3\x01\n\rPackageStatus\x12\x1e\n\x1aPACKAGE_STATUS_UNSPECIFIED\x10\x00\x12\x19\n\x15PACKAGE_STATUS_FAILED\x10\x01\x12\x1b\n\x17PACKAGE_STATUS_REJECTED\x10\x02\x12\x1b\n\x17PACKAGE_STATUS_COMPLETE\x10\x03\x12\x1d\n\x19PACKAGE_STATUS_PROCESSING\x10\x04\x42\xb1\x02\n#com.a3m.api.transferservice.v1beta1B\x14RequestResponseProtoP\x01ZUgithub.com/artefactual-labs/a3m/proto/a3m/api/transferservice/v1beta1;transferservice\xa2\x02\x03\x41\x41T\xaa\x02\x1f\x41\x33m.Api.Transferservice.V1beta1\xca\x02\x1f\x41\x33m\\Api\\Transferservice\\V1beta1\xe2\x02+A3m\\Api\\Transferservice\\V1beta1\\GPBMetadata\xea\x02"A3m::Api::Transferservice::V1beta1b\x06proto3'
 )
 
-_builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
+_globals = globals()
+_builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(
-    DESCRIPTOR, "a3m.api.transferservice.v1beta1.request_response_pb2", globals()
+    DESCRIPTOR, "a3m.api.transferservice.v1beta1.request_response_pb2", _globals
 )
 if _descriptor._USE_C_DESCRIPTORS == False:
 
     DESCRIPTOR._options = None
     DESCRIPTOR._serialized_options = b'\n#com.a3m.api.transferservice.v1beta1B\024RequestResponseProtoP\001ZUgithub.com/artefactual-labs/a3m/proto/a3m/api/transferservice/v1beta1;transferservice\242\002\003AAT\252\002\037A3m.Api.Transferservice.V1beta1\312\002\037A3m\\Api\\Transferservice\\V1beta1\342\002+A3m\\Api\\Transferservice\\V1beta1\\GPBMetadata\352\002"A3m::Api::Transferservice::V1beta1'
-    _PACKAGESTATUS._serialized_start = 2648
-    _PACKAGESTATUS._serialized_end = 2811
-    _SUBMITREQUEST._serialized_start = 125
-    _SUBMITREQUEST._serialized_end = 253
-    _SUBMITRESPONSE._serialized_start = 255
-    _SUBMITRESPONSE._serialized_end = 287
-    _READREQUEST._serialized_start = 289
-    _READREQUEST._serialized_end = 318
-    _READRESPONSE._serialized_start = 321
-    _READRESPONSE._serialized_end = 483
-    _LISTTASKSREQUEST._serialized_start = 485
-    _LISTTASKSREQUEST._serialized_end = 526
-    _LISTTASKSRESPONSE._serialized_start = 528
-    _LISTTASKSRESPONSE._serialized_end = 608
-    _EMPTYREQUEST._serialized_start = 610
-    _EMPTYREQUEST._serialized_end = 624
-    _EMPTYRESPONSE._serialized_start = 626
-    _EMPTYRESPONSE._serialized_end = 641
-    _JOB._serialized_start = 644
-    _JOB._serialized_end = 957
-    _JOB_STATUS._serialized_start = 862
-    _JOB_STATUS._serialized_end = 957
-    _TASK._serialized_start = 960
-    _TASK._serialized_end = 1286
-    _PROCESSINGCONFIG._serialized_start = 1289
-    _PROCESSINGCONFIG._serialized_end = 2645
-    _PROCESSINGCONFIG_AIPCOMPRESSIONALGORITHM._serialized_start = 2299
-    _PROCESSINGCONFIG_AIPCOMPRESSIONALGORITHM._serialized_end = 2645
+    _globals["_PACKAGESTATUS"]._serialized_start = 2648
+    _globals["_PACKAGESTATUS"]._serialized_end = 2811
+    _globals["_SUBMITREQUEST"]._serialized_start = 125
+    _globals["_SUBMITREQUEST"]._serialized_end = 253
+    _globals["_SUBMITRESPONSE"]._serialized_start = 255
+    _globals["_SUBMITRESPONSE"]._serialized_end = 287
+    _globals["_READREQUEST"]._serialized_start = 289
+    _globals["_READREQUEST"]._serialized_end = 318
+    _globals["_READRESPONSE"]._serialized_start = 321
+    _globals["_READRESPONSE"]._serialized_end = 483
+    _globals["_LISTTASKSREQUEST"]._serialized_start = 485
+    _globals["_LISTTASKSREQUEST"]._serialized_end = 526
+    _globals["_LISTTASKSRESPONSE"]._serialized_start = 528
+    _globals["_LISTTASKSRESPONSE"]._serialized_end = 608
+    _globals["_EMPTYREQUEST"]._serialized_start = 610
+    _globals["_EMPTYREQUEST"]._serialized_end = 624
+    _globals["_EMPTYRESPONSE"]._serialized_start = 626
+    _globals["_EMPTYRESPONSE"]._serialized_end = 641
+    _globals["_JOB"]._serialized_start = 644
+    _globals["_JOB"]._serialized_end = 957
+    _globals["_JOB_STATUS"]._serialized_start = 862
+    _globals["_JOB_STATUS"]._serialized_end = 957
+    _globals["_TASK"]._serialized_start = 960
+    _globals["_TASK"]._serialized_end = 1286
+    _globals["_PROCESSINGCONFIG"]._serialized_start = 1289
+    _globals["_PROCESSINGCONFIG"]._serialized_end = 2645
+    _globals["_PROCESSINGCONFIG_AIPCOMPRESSIONALGORITHM"]._serialized_start = 2299
+    _globals["_PROCESSINGCONFIG_AIPCOMPRESSIONALGORITHM"]._serialized_end = 2645
 # @@protoc_insertion_point(module_scope)

--- a/a3m/api/transferservice/v1beta1/request_response_pb2.pyi
+++ b/a3m/api/transferservice/v1beta1/request_response_pb2.pyi
@@ -3,13 +3,19 @@
 isort:skip_file
 """
 import builtins
+import collections.abc
 import google.protobuf.descriptor
 import google.protobuf.internal.containers
 import google.protobuf.internal.enum_type_wrapper
 import google.protobuf.message
 import google.protobuf.timestamp_pb2
+import sys
 import typing
-import typing_extensions
+
+if sys.version_info >= (3, 10):
+    import typing as typing_extensions
+else:
+    import typing_extensions
 
 DESCRIPTOR: google.protobuf.descriptor.FileDescriptor
 
@@ -30,8 +36,7 @@ class _PackageStatusEnumTypeWrapper(
     PACKAGE_STATUS_COMPLETE: _PackageStatus.ValueType  # 3
     PACKAGE_STATUS_PROCESSING: _PackageStatus.ValueType  # 4
 
-class PackageStatus(_PackageStatus, metaclass=_PackageStatusEnumTypeWrapper):
-    pass
+class PackageStatus(_PackageStatus, metaclass=_PackageStatusEnumTypeWrapper): ...
 
 PACKAGE_STATUS_UNSPECIFIED: PackageStatus.ValueType  # 0
 PACKAGE_STATUS_FAILED: PackageStatus.ValueType  # 1
@@ -40,21 +45,23 @@ PACKAGE_STATUS_COMPLETE: PackageStatus.ValueType  # 3
 PACKAGE_STATUS_PROCESSING: PackageStatus.ValueType  # 4
 global___PackageStatus = PackageStatus
 
+@typing_extensions.final
 class SubmitRequest(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
+
     NAME_FIELD_NUMBER: builtins.int
     URL_FIELD_NUMBER: builtins.int
     CONFIG_FIELD_NUMBER: builtins.int
-    name: typing.Text
-    url: typing.Text
+    name: builtins.str
+    url: builtins.str
     @property
     def config(self) -> global___ProcessingConfig: ...
     def __init__(
         self,
         *,
-        name: typing.Text = ...,
-        url: typing.Text = ...,
-        config: typing.Optional[global___ProcessingConfig] = ...,
+        name: builtins.str = ...,
+        url: builtins.str = ...,
+        config: global___ProcessingConfig | None = ...,
     ) -> None: ...
     def HasField(
         self, field_name: typing_extensions.Literal["config", b"config"]
@@ -68,14 +75,16 @@ class SubmitRequest(google.protobuf.message.Message):
 
 global___SubmitRequest = SubmitRequest
 
+@typing_extensions.final
 class SubmitResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
+
     ID_FIELD_NUMBER: builtins.int
-    id: typing.Text
+    id: builtins.str
     def __init__(
         self,
         *,
-        id: typing.Text = ...,
+        id: builtins.str = ...,
     ) -> None: ...
     def ClearField(
         self, field_name: typing_extensions.Literal["id", b"id"]
@@ -83,14 +92,16 @@ class SubmitResponse(google.protobuf.message.Message):
 
 global___SubmitResponse = SubmitResponse
 
+@typing_extensions.final
 class ReadRequest(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
+
     ID_FIELD_NUMBER: builtins.int
-    id: typing.Text
+    id: builtins.str
     def __init__(
         self,
         *,
-        id: typing.Text = ...,
+        id: builtins.str = ...,
     ) -> None: ...
     def ClearField(
         self, field_name: typing_extensions.Literal["id", b"id"]
@@ -98,13 +109,15 @@ class ReadRequest(google.protobuf.message.Message):
 
 global___ReadRequest = ReadRequest
 
+@typing_extensions.final
 class ReadResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
+
     STATUS_FIELD_NUMBER: builtins.int
     JOB_FIELD_NUMBER: builtins.int
     JOBS_FIELD_NUMBER: builtins.int
     status: global___PackageStatus.ValueType
-    job: typing.Text
+    job: builtins.str
     @property
     def jobs(
         self,
@@ -115,8 +128,8 @@ class ReadResponse(google.protobuf.message.Message):
         self,
         *,
         status: global___PackageStatus.ValueType = ...,
-        job: typing.Text = ...,
-        jobs: typing.Optional[typing.Iterable[global___Job]] = ...,
+        job: builtins.str = ...,
+        jobs: collections.abc.Iterable[global___Job] | None = ...,
     ) -> None: ...
     def ClearField(
         self,
@@ -127,14 +140,16 @@ class ReadResponse(google.protobuf.message.Message):
 
 global___ReadResponse = ReadResponse
 
+@typing_extensions.final
 class ListTasksRequest(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
+
     JOB_ID_FIELD_NUMBER: builtins.int
-    job_id: typing.Text
+    job_id: builtins.str
     def __init__(
         self,
         *,
-        job_id: typing.Text = ...,
+        job_id: builtins.str = ...,
     ) -> None: ...
     def ClearField(
         self, field_name: typing_extensions.Literal["job_id", b"job_id"]
@@ -142,8 +157,10 @@ class ListTasksRequest(google.protobuf.message.Message):
 
 global___ListTasksRequest = ListTasksRequest
 
+@typing_extensions.final
 class ListTasksResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
+
     TASKS_FIELD_NUMBER: builtins.int
     @property
     def tasks(
@@ -154,7 +171,7 @@ class ListTasksResponse(google.protobuf.message.Message):
     def __init__(
         self,
         *,
-        tasks: typing.Optional[typing.Iterable[global___Task]] = ...,
+        tasks: collections.abc.Iterable[global___Task] | None = ...,
     ) -> None: ...
     def ClearField(
         self, field_name: typing_extensions.Literal["tasks", b"tasks"]
@@ -162,22 +179,27 @@ class ListTasksResponse(google.protobuf.message.Message):
 
 global___ListTasksResponse = ListTasksResponse
 
+@typing_extensions.final
 class EmptyRequest(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
+
     def __init__(
         self,
     ) -> None: ...
 
 global___EmptyRequest = EmptyRequest
 
+@typing_extensions.final
 class EmptyResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
+
     def __init__(
         self,
     ) -> None: ...
 
 global___EmptyResponse = EmptyResponse
 
+@typing_extensions.final
 class Job(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -197,8 +219,7 @@ class Job(google.protobuf.message.Message):
         STATUS_PROCESSING: Job._Status.ValueType  # 2
         STATUS_FAILED: Job._Status.ValueType  # 3
 
-    class Status(_Status, metaclass=_StatusEnumTypeWrapper):
-        pass
+    class Status(_Status, metaclass=_StatusEnumTypeWrapper): ...
     STATUS_UNSPECIFIED: Job.Status.ValueType  # 0
     STATUS_COMPLETE: Job.Status.ValueType  # 1
     STATUS_PROCESSING: Job.Status.ValueType  # 2
@@ -210,22 +231,22 @@ class Job(google.protobuf.message.Message):
     LINK_ID_FIELD_NUMBER: builtins.int
     STATUS_FIELD_NUMBER: builtins.int
     START_TIME_FIELD_NUMBER: builtins.int
-    id: typing.Text
-    name: typing.Text
-    group: typing.Text
-    link_id: typing.Text
+    id: builtins.str
+    name: builtins.str
+    group: builtins.str
+    link_id: builtins.str
     status: global___Job.Status.ValueType
     @property
     def start_time(self) -> google.protobuf.timestamp_pb2.Timestamp: ...
     def __init__(
         self,
         *,
-        id: typing.Text = ...,
-        name: typing.Text = ...,
-        group: typing.Text = ...,
-        link_id: typing.Text = ...,
+        id: builtins.str = ...,
+        name: builtins.str = ...,
+        group: builtins.str = ...,
+        link_id: builtins.str = ...,
         status: global___Job.Status.ValueType = ...,
-        start_time: typing.Optional[google.protobuf.timestamp_pb2.Timestamp] = ...,
+        start_time: google.protobuf.timestamp_pb2.Timestamp | None = ...,
     ) -> None: ...
     def HasField(
         self, field_name: typing_extensions.Literal["start_time", b"start_time"]
@@ -250,8 +271,10 @@ class Job(google.protobuf.message.Message):
 
 global___Job = Job
 
+@typing_extensions.final
 class Task(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
+
     ID_FIELD_NUMBER: builtins.int
     FILE_ID_FIELD_NUMBER: builtins.int
     EXIT_CODE_FIELD_NUMBER: builtins.int
@@ -262,14 +285,14 @@ class Task(google.protobuf.message.Message):
     STDERR_FIELD_NUMBER: builtins.int
     START_TIME_FIELD_NUMBER: builtins.int
     END_TIME_FIELD_NUMBER: builtins.int
-    id: typing.Text
-    file_id: typing.Text
+    id: builtins.str
+    file_id: builtins.str
     exit_code: builtins.int
-    filename: typing.Text
-    execution: typing.Text
-    arguments: typing.Text
-    stdout: typing.Text
-    stderr: typing.Text
+    filename: builtins.str
+    execution: builtins.str
+    arguments: builtins.str
+    stdout: builtins.str
+    stderr: builtins.str
     @property
     def start_time(self) -> google.protobuf.timestamp_pb2.Timestamp: ...
     @property
@@ -277,16 +300,16 @@ class Task(google.protobuf.message.Message):
     def __init__(
         self,
         *,
-        id: typing.Text = ...,
-        file_id: typing.Text = ...,
+        id: builtins.str = ...,
+        file_id: builtins.str = ...,
         exit_code: builtins.int = ...,
-        filename: typing.Text = ...,
-        execution: typing.Text = ...,
-        arguments: typing.Text = ...,
-        stdout: typing.Text = ...,
-        stderr: typing.Text = ...,
-        start_time: typing.Optional[google.protobuf.timestamp_pb2.Timestamp] = ...,
-        end_time: typing.Optional[google.protobuf.timestamp_pb2.Timestamp] = ...,
+        filename: builtins.str = ...,
+        execution: builtins.str = ...,
+        arguments: builtins.str = ...,
+        stdout: builtins.str = ...,
+        stderr: builtins.str = ...,
+        start_time: google.protobuf.timestamp_pb2.Timestamp | None = ...,
+        end_time: google.protobuf.timestamp_pb2.Timestamp | None = ...,
     ) -> None: ...
     def HasField(
         self,
@@ -322,6 +345,7 @@ class Task(google.protobuf.message.Message):
 
 global___Task = Task
 
+@typing_extensions.final
 class ProcessingConfig(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
@@ -339,10 +363,8 @@ class ProcessingConfig(google.protobuf.message.Message):
         AIP_COMPRESSION_ALGORITHM_UNSPECIFIED: ProcessingConfig._AIPCompressionAlgorithm.ValueType  # 0
         AIP_COMPRESSION_ALGORITHM_UNCOMPRESSED: ProcessingConfig._AIPCompressionAlgorithm.ValueType  # 1
         """It breaks in verify_aip."""
-
         AIP_COMPRESSION_ALGORITHM_TAR: ProcessingConfig._AIPCompressionAlgorithm.ValueType  # 2
         """Not supported yet!"""
-
         AIP_COMPRESSION_ALGORITHM_TAR_BZIP2: ProcessingConfig._AIPCompressionAlgorithm.ValueType  # 3
         AIP_COMPRESSION_ALGORITHM_TAR_GZIP: ProcessingConfig._AIPCompressionAlgorithm.ValueType  # 4
         AIP_COMPRESSION_ALGORITHM_S7_COPY: ProcessingConfig._AIPCompressionAlgorithm.ValueType  # 5
@@ -351,15 +373,12 @@ class ProcessingConfig(google.protobuf.message.Message):
 
     class AIPCompressionAlgorithm(
         _AIPCompressionAlgorithm, metaclass=_AIPCompressionAlgorithmEnumTypeWrapper
-    ):
-        pass
+    ): ...
     AIP_COMPRESSION_ALGORITHM_UNSPECIFIED: ProcessingConfig.AIPCompressionAlgorithm.ValueType  # 0
     AIP_COMPRESSION_ALGORITHM_UNCOMPRESSED: ProcessingConfig.AIPCompressionAlgorithm.ValueType  # 1
     """It breaks in verify_aip."""
-
     AIP_COMPRESSION_ALGORITHM_TAR: ProcessingConfig.AIPCompressionAlgorithm.ValueType  # 2
     """Not supported yet!"""
-
     AIP_COMPRESSION_ALGORITHM_TAR_BZIP2: ProcessingConfig.AIPCompressionAlgorithm.ValueType  # 3
     AIP_COMPRESSION_ALGORITHM_TAR_GZIP: ProcessingConfig.AIPCompressionAlgorithm.ValueType  # 4
     AIP_COMPRESSION_ALGORITHM_S7_COPY: ProcessingConfig.AIPCompressionAlgorithm.ValueType  # 5
@@ -394,7 +413,6 @@ class ProcessingConfig(google.protobuf.message.Message):
     in the workflow: one for objects/submissionDocumentation and one
     for objects/metadata
     """
-
     identify_before_normalization: builtins.bool
     normalize: builtins.bool
     transcribe_files: builtins.bool
@@ -402,10 +420,8 @@ class ProcessingConfig(google.protobuf.message.Message):
     perform_policy_checks_on_preservation_derivatives: builtins.bool
     aip_compression_level: builtins.int
     """AIP compression level (1 is the fastest, 9 is the smallest)."""
-
     aip_compression_algorithm: global___ProcessingConfig.AIPCompressionAlgorithm.ValueType
     """AIP compression algorithm"""
-
     def __init__(
         self,
         *,

--- a/a3m/api/transferservice/v1beta1/service_pb2.py
+++ b/a3m/api/transferservice/v1beta1/service_pb2.py
@@ -20,14 +20,15 @@ DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
     b'\n-a3m/api/transferservice/v1beta1/service.proto\x12\x1f\x61\x33m.api.transferservice.v1beta1\x1a\x36\x61\x33m/api/transferservice/v1beta1/request_response.proto2\xc5\x03\n\x0fTransferService\x12k\n\x06Submit\x12..a3m.api.transferservice.v1beta1.SubmitRequest\x1a/.a3m.api.transferservice.v1beta1.SubmitResponse"\x00\x12\x65\n\x04Read\x12,.a3m.api.transferservice.v1beta1.ReadRequest\x1a-.a3m.api.transferservice.v1beta1.ReadResponse"\x00\x12t\n\tListTasks\x12\x31.a3m.api.transferservice.v1beta1.ListTasksRequest\x1a\x32.a3m.api.transferservice.v1beta1.ListTasksResponse"\x00\x12h\n\x05\x45mpty\x12-.a3m.api.transferservice.v1beta1.EmptyRequest\x1a..a3m.api.transferservice.v1beta1.EmptyResponse"\x00\x42\xa9\x02\n#com.a3m.api.transferservice.v1beta1B\x0cServiceProtoP\x01ZUgithub.com/artefactual-labs/a3m/proto/a3m/api/transferservice/v1beta1;transferservice\xa2\x02\x03\x41\x41T\xaa\x02\x1f\x41\x33m.Api.Transferservice.V1beta1\xca\x02\x1f\x41\x33m\\Api\\Transferservice\\V1beta1\xe2\x02+A3m\\Api\\Transferservice\\V1beta1\\GPBMetadata\xea\x02"A3m::Api::Transferservice::V1beta1b\x06proto3'
 )
 
-_builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
+_globals = globals()
+_builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(
-    DESCRIPTOR, "a3m.api.transferservice.v1beta1.service_pb2", globals()
+    DESCRIPTOR, "a3m.api.transferservice.v1beta1.service_pb2", _globals
 )
 if _descriptor._USE_C_DESCRIPTORS == False:
 
     DESCRIPTOR._options = None
     DESCRIPTOR._serialized_options = b'\n#com.a3m.api.transferservice.v1beta1B\014ServiceProtoP\001ZUgithub.com/artefactual-labs/a3m/proto/a3m/api/transferservice/v1beta1;transferservice\242\002\003AAT\252\002\037A3m.Api.Transferservice.V1beta1\312\002\037A3m\\Api\\Transferservice\\V1beta1\342\002+A3m\\Api\\Transferservice\\V1beta1\\GPBMetadata\352\002"A3m::Api::Transferservice::V1beta1'
-    _TRANSFERSERVICE._serialized_start = 139
-    _TRANSFERSERVICE._serialized_end = 592
+    _globals["_TRANSFERSERVICE"]._serialized_start = 139
+    _globals["_TRANSFERSERVICE"]._serialized_end = 592
 # @@protoc_insertion_point(module_scope)

--- a/proto/buf.gen.yaml
+++ b/proto/buf.gen.yaml
@@ -2,9 +2,9 @@ version: v1
 managed:
   enabled: true
 plugins:
-  - remote: buf.build/protocolbuffers/plugins/python:v3.20.1-1
+  - plugin: buf.build/protocolbuffers/python:v23.4
     out: ../
-  - remote: buf.build/grpc/plugins/python:v1.46.3-1
+  - plugin: buf.build/grpc/python:v1.56.2
     out: ../
-  - remote: buf.build/adriansahlman/plugins/mypy-protobuf:v3.2.0-1
+  - plugin: buf.build/community/nipunn1313-mypy:v3.5.0
     out: ../


### PR DESCRIPTION
Fixes issue #354

Buf.build (https://buf.build/) remote generation alpha has been disabled breaking the remote plugin generation in a3m.  This commit updates `buf.gen.yaml` to use the correct syntax and current plugins.