### PR TITLE
Use local XML schemas for XML validation

### DIFF
--- a/a3m/cli/client/__main__.py
+++ b/a3m/cli/client/__main__.py
@@ -13,6 +13,7 @@ from rich.table import Table
 
 from a3m.api.transferservice import v1beta1 as transfer_service_api
 from a3m.cli.client.wrapper import ClientWrapper
+from a3m.cli.common import configure_xml_catalog_files
 from a3m.cli.common import init_django
 from a3m.cli.common import suppress_warnings
 from a3m.server.rpc.client import Client
@@ -53,6 +54,7 @@ def main(ctx, uri, name, address, processing_config, wait_for_ready, no_input):
     """
     init_django()
     suppress_warnings()
+    configure_xml_catalog_files()
 
     # Disable logging.
     if not settings.DEBUG:

--- a/a3m/cli/common.py
+++ b/a3m/cli/common.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 import sys
 import warnings
 
@@ -25,3 +26,10 @@ def init_django():
     """
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "a3m.settings.common")
     django.setup()
+
+
+def configure_xml_catalog_files():
+    """Use local XML schemas for validation."""
+    os.environ["XML_CATALOG_FILES"] = str(
+        pathlib.Path(__file__).parent.parent / "client/assets/catalog/catalog.xml"
+    )

--- a/a3m/cli/server/__main__.py
+++ b/a3m/cli/server/__main__.py
@@ -7,6 +7,7 @@ import grpc
 from django.conf import settings
 
 from a3m import __version__
+from a3m.cli.common import configure_xml_catalog_files
 from a3m.cli.common import init_django
 from a3m.cli.common import suppress_warnings
 
@@ -17,6 +18,7 @@ logger = logging.getLogger(__name__)
 def main():
     init_django()
     suppress_warnings()
+    configure_xml_catalog_files()
 
     from a3m.server.runner import create_server
 

--- a/a3m/client/__init__.py
+++ b/a3m/client/__init__.py
@@ -1,6 +1,12 @@
 import os
+import pathlib
 
 
 THIS_DIR = os.path.dirname(__file__)
 
 ASSETS_DIR = os.path.join(THIS_DIR, "assets", "")
+
+# Use local XML schemas for validation.
+os.environ["XML_CATALOG_FILES"] = str(
+    pathlib.Path(__file__).parent / "assets/catalog/catalog.xml"
+)

--- a/a3m/client/assets/catalog/catalog.xml
+++ b/a3m/client/assets/catalog/catalog.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<!DOCTYPE catalog PUBLIC "-//OASIS//DTD Entity Resolution XML Catalog V1.0//EN" "http://www.oasis-open.org/committees/entity/release/1.0/catalog.dtd">
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+
+  <group prefer="system">
+    <system
+      systemId="http://www.loc.gov/standards/xlink/xlink.xsd"
+      uri="../mets/xlink.xsd" />
+
+    <system
+      systemId="http://www.loc.gov/standards/mets/version1121/mets.xsd"
+      uri="../mets/mets.xsd" />
+
+    <system
+      systemId="http://www.loc.gov/standards/premis/v3/premis.xsd"
+      uri="../premis/premis.xsd" />
+
+    <!-- mets-reader-writer still validates against PREMIS 2.2 -->
+    <system
+      systemId="http://www.loc.gov/standards/premis/v2/premis-v2-2.xsd"
+      uri="../premis/premis-v2-2.xsd" />
+
+    <system
+      systemId="http://www.loc.gov/mods/xml.xsd"
+      uri="../mods/xml.xsd" />
+
+    <system
+      systemId="http://www.loc.gov/standards/mods/v3/mods.xsd"
+      uri="../mods/mods.xsd" />
+
+  </group>
+
+</catalog>

--- a/a3m/client/assets/mets/xlink.xsd
+++ b/a3m/client/assets/mets/xlink.xsd
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- METS XLink Schema, v. 2, Nov. 15, 2004 -->
+<schema targetNamespace="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:xlink="http://www.w3.org/1999/xlink" elementFormDefault="qualified">
+  <!--  global attributes  --> 
+  <attribute name="href"  type="anyURI"/>
+  <attribute name="role" type="string"/>
+  <attribute name="arcrole" type="string"/>
+  <attribute name="title" type="string" /> 
+  <attribute name="show">
+    <simpleType>
+      <restriction base="string">
+	<enumeration value="new" /> 
+	<enumeration value="replace" /> 
+	<enumeration value="embed" /> 
+	<enumeration value="other" /> 
+	<enumeration value="none" /> 
+      </restriction>
+    </simpleType>
+  </attribute>
+  <attribute name="actuate">
+    <simpleType>
+      <restriction base="string">
+	<enumeration value="onLoad" /> 
+	<enumeration value="onRequest" /> 
+	<enumeration value="other" /> 
+	<enumeration value="none" /> 
+      </restriction>
+    </simpleType>
+  </attribute>
+  <attribute name="label" type="string" /> 
+  <attribute name="from" type="string" /> 
+  <attribute name="to" type="string" /> 
+  <attributeGroup name="simpleLink">
+    <attribute name="type" type="string" fixed="simple" form="qualified" /> 
+    <attribute ref="xlink:href" use="optional" /> 
+    <attribute ref="xlink:role" use="optional" /> 
+    <attribute ref="xlink:arcrole" use="optional" /> 
+    <attribute ref="xlink:title" use="optional" /> 
+    <attribute ref="xlink:show" use="optional" /> 
+    <attribute ref="xlink:actuate" use="optional" /> 
+  </attributeGroup>
+  <attributeGroup name="extendedLink">
+    <attribute name="type" type="string" fixed="extended" form="qualified" /> 
+    <attribute ref="xlink:role" use="optional" /> 
+    <attribute ref="xlink:title" use="optional" /> 
+  </attributeGroup>
+  <attributeGroup name="locatorLink">
+    <attribute name="type" type="string" fixed="locator" form="qualified" /> 
+    <attribute ref="xlink:href" use="required" /> 
+    <attribute ref="xlink:role" use="optional" /> 
+    <attribute ref="xlink:title" use="optional" /> 
+    <attribute ref="xlink:label" use="optional" /> 
+  </attributeGroup>
+  <attributeGroup name="arcLink">
+    <attribute name="type" type="string" fixed="arc" form="qualified" /> 
+    <attribute ref="xlink:arcrole" use="optional" /> 
+    <attribute ref="xlink:title" use="optional" /> 
+    <attribute ref="xlink:show" use="optional" /> 
+    <attribute ref="xlink:actuate" use="optional" /> 
+    <attribute ref="xlink:from" use="optional" /> 
+    <attribute ref="xlink:to" use="optional" /> 
+  </attributeGroup>
+  <attributeGroup name="resourceLink">
+    <attribute name="type" type="string" fixed="resource" form="qualified" /> 
+    <attribute ref="xlink:role" use="optional" /> 
+    <attribute ref="xlink:title" use="optional" /> 
+    <attribute ref="xlink:label" use="optional" /> 
+  </attributeGroup>
+  <attributeGroup name="titleLink">
+    <attribute name="type" type="string" fixed="title" form="qualified" /> 
+  </attributeGroup>
+  <attributeGroup name="emptyLink">
+    <attribute name="type" type="string" fixed="none" form="qualified" /> 
+  </attributeGroup>
+</schema>

--- a/a3m/client/assets/mods/mods.xsd
+++ b/a3m/client/assets/mods/mods.xsd
@@ -1,0 +1,1771 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--  
+	Library of Congress
+	
+Editor: Ray Denenberg	raydenenberg@gmail.com 
+ -->
+<xs:schema xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	xmlns="http://www.loc.gov/mods/v3" targetNamespace="http://www.loc.gov/mods/v3"
+	elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<!-- -->
+	<xs:import namespace="http://www.w3.org/XML/1998/namespace"
+		schemaLocation="http://www.loc.gov/mods/xml.xsd"/>
+	<xs:import namespace="http://www.w3.org/1999/xlink"
+		schemaLocation="http://www.loc.gov/standards/xlink/xlink.xsd"/>
+	<!-- 
+MODS: Metadata Object Description Schema. See http://www.loc.gov/standards/mods/
+
+          *******************************************************************
+         *                                                                                
+         *                          MODS 3.8
+         *         
+         *                     September 16, 2022
+         *             
+          *********************************************************************
+
+********* November 10, 2022 the attribute @supplied has been added to the <name> definition.
+
+*************** Changes in version 3.8
+
+1. Controlled-list restriction removed on authority attribute 
+   for <placeTerm> <geographic Code> and <languageTerm>.	
+
+2.  Attributes @otherTypeAuth,  @otherTypeAuthURI,  and @otherTypeURI added for <titleInfo>.
+
+3. Element <agent>  added, subelement of <originInfo>.
+   
+4. Authority attributes added for <accessCondition> and for <affiliation>. 
+
+5. Attribute @usage added for <recordInfo>, value "primary".
+
+6. Attribute @IDref added to any element that has the @ID attribute; 
+   attributes @ID and @idref added to top-level elements that have neither.
+
+7. Element <nameIdentifier> element added, subelement of <place>.
+
+8. Element <cartographics> added, subelement of <place>.
+
+9. Attribute @stateType added, subelement of <subject><hierarchicalGeographic><state>.
+
+10.  Element <displayDate> added, subelement of <originInfo>.
+
+11.  Attribute @eventTypeURI added to <originInfo>.
+
+12.  Attribute @usage of <location><url>, value "primary display" deprecated.
+
+13. All occurrences of @fixed removed, replaced by a single-value controlled list,
+    where the value is the previous value of @fixed.
+
+14. @type  added to <extension>.
+
+***************************************************
+***************************************************
+
+
+
+     *************************************
+     Organization of this schema
+     *************************************
+
+The schema has three parts:
+
+1.   Structural declarations and definitions 
+2.    Elements (top level elements  and their subelements)
+3.   Auxiliary Definitions 
+
+         ***********************************************************************
+         ***********************************************************************
+         Part 1:    Structural Declarations and Definitions 
+         ***********************************************************************
+         ***********************************************************************
+- Definition of a single MODS record  and a MODS collection   
+- modsGroup, listing the top level MODS elements
+
+***********************************************************************
+**      Definition of a single MODS record                           **
+**********************************************************************
+-->
+	<xs:element name="mods" type="modsDefinition"/>
+	<!--  -->
+	<xs:complexType name="modsDefinition">
+		<xs:group ref="modsGroup" maxOccurs="unbounded"/>
+		<!--
+****************** @IDREF added in 3.8 (@ID removed and replaced by the following)-->
+		<xs:attributeGroup ref="IDAttributeGroup"/>
+		<!-- -->
+		<xs:attribute name="version">
+			<xs:simpleType>
+				<xs:restriction base="xs:string">
+					<xs:enumeration value="3.8"/>
+					<xs:enumeration value="3.7"/>
+					<xs:enumeration value="3.6"/>
+					<xs:enumeration value="3.5"/>
+					<xs:enumeration value="3.4"/>
+					<xs:enumeration value="3.3"/>
+					<xs:enumeration value="3.2"/>
+					<xs:enumeration value="3.1"/>
+					<xs:enumeration value="3.0"/>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+	</xs:complexType>
+	<!-- 
+***********************************************************************
+**      Definition of a MODS collection                                **
+**********************************************************************
+-->
+	<xs:element name="modsCollection" type="modsCollectionDefinition"/>
+	<!-- -->
+	<xs:complexType name="modsCollectionDefinition">
+		<xs:sequence>
+			<xs:element ref="mods" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--  
+
+************************************************
+**      Group Definition 
+***********************************************
+This forms the basis of the mods record definition, and also relatedItem. 
+The difference between a MODS record and a relatedItem 
+(as they pertain to their usage of the group definition) 
+is that mods requires at least one element and relatedItem does not. 
+The group definition is used by both, where relatedItem says 
+minOccurs="0" and for the mods record definition minOccurs="1" (default).
+
+-->
+	<xs:group name="modsGroup">
+		<xs:choice>
+			<!-- 
+***********************************************************************
+**        These are the "top level" MODS elements               **
+**********************************************************************
+-->
+			<xs:element ref="abstract"/>
+			<xs:element ref="accessCondition"/>
+			<xs:element ref="classification"/>
+			<xs:element ref="extension"/>
+			<xs:element ref="genre"/>
+			<xs:element ref="identifier"/>
+			<xs:element ref="language"/>
+			<xs:element ref="location"/>
+			<xs:element ref="name"/>
+			<xs:element ref="note"/>
+			<xs:element ref="originInfo"/>
+			<xs:element ref="part"/>
+			<xs:element ref="physicalDescription"/>
+			<xs:element ref="recordInfo"/>
+			<xs:element ref="relatedItem"/>
+			<xs:element ref="subject"/>
+			<xs:element ref="tableOfContents"/>
+			<xs:element ref="targetAudience"/>
+			<xs:element ref="titleInfo"/>
+			<xs:element ref="typeOfResource"/>
+			<!-- 
+End list of "top level" MODS elements 
+-->
+		</xs:choice>
+	</xs:group>
+	<!--	
+        ***********************************************************************
+        ***********************************************************************
+       Part 2:   Elements (top level elements and their subelements)                               
+       ************************************************************************
+        ***********************************************************************                              
+-->
+	<!--   
+*********************************************
+*   Top Level Element <abstract>       *
+*********************************************
+ -->
+	<xs:element name="abstract" type="abstractDefinition"/>
+	<!-- -->
+	<xs:complexType name="abstractDefinition">
+		<xs:simpleContent>
+			<xs:extension base="stringPlusLanguage">
+				<xs:attribute name="displayLabel" type="xs:string"/>
+				<xs:attribute name="type" type="xs:string"/>
+				<xs:attributeGroup ref="xlink:simpleLink"/>
+				<!-- 
+					@sharable definition corrected in 3.8.  
+					See "Changes in version 3.8" #13-->
+				<xs:attribute name="shareable" type="no"/>
+				<!--  -->
+				<xs:attribute name="altRepGroup" type="xs:string"/>
+				<xs:attributeGroup ref="altFormatAttributeGroup"/>
+				<!-- 
+****************** following attribute group added in 3.8-->
+				<xs:attributeGroup ref="IDAttributeGroup"/>
+				<!-- -->
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<!--
+
+****************************************************
+*   Top Level Element <accessCondition>       *
+*****************************************************
+ -->
+	<xs:element name="accessCondition" type="accessConditionDefinition"/>
+	<!-- -->
+	<xs:complexType name="accessConditionDefinition" mixed="true">
+		<xs:complexContent mixed="true">
+			<xs:extension base="extensionDefinition">
+				<xs:attributeGroup ref="xlink:simpleLink"/>
+				<xs:attributeGroup ref="languageAttributeGroup"/>
+				<!-- 
+			Previously attribute @type was here. It is 
+			removed  in 3.8 because it has been added 
+			to the "extension" defintion;  "accessCondition"
+			is based on the "extension definition" so @type is
+			thereby implicitly included in this definition.
+				-->
+				<xs:attribute name="altRepGroup" type="xs:string"/>
+				<xs:attributeGroup ref="altFormatAttributeGroup"/>
+				<!-- 
+****************** following two attribute groups added in 3.8-->
+				<xs:attributeGroup ref="IDAttributeGroup"/>
+				<xs:attributeGroup ref="authorityAttributeGroup"/>
+				<!--  -->
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--
+****************************************************
+*   Top Level Element <classification>          *
+*****************************************************
+-->
+	<xs:element name="classification" type="classificationDefinition"/>
+	<!-- -->
+	<xs:complexType name="classificationDefinition">
+		<xs:simpleContent>
+			<xs:extension base="stringPlusLanguagePlusAuthority">
+				<xs:attribute name="edition" type="xs:string"/>
+				<xs:attribute name="displayLabel" type="xs:string"/>
+				<xs:attribute name="altRepGroup" type="xs:string"/>
+				<!-- 
+					@usage definition corrected in 3.8.  
+					See "Changes in version 3.8" #13-->
+				<xs:attribute name="usage" type="usagePrimary"/>
+				<!-- -->
+				<xs:attribute name="generator" type="xs:string"/>
+				<!-- 
+****************** following  attribute group added in 3.8-->
+				<xs:attributeGroup ref="IDAttributeGroup"/>
+				<!--  -->
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<!--
+****************************************************
+*   Top Level Element <extension>              *
+*****************************************************
+ -->
+	<xs:element name="extension" type="extensionDefinition"/>
+	<!-- -->
+	<xs:complexType name="extensionDefinition" mixed="true">
+		<xs:sequence>
+			<xs:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="displayLabel" type="xs:string"/>
+		<!-- 
+****************** following  attribute added in 3.8 -->
+		<xs:attribute name="type" type="xs:string"/>
+		<!-- 
+****************** following  attribute group added in 3.8-->
+		<xs:attributeGroup ref="IDAttributeGroup"/>
+		<!--  -->
+	</xs:complexType>
+	<!--  
+****************************************************
+*   Top Level Element <genre>                    *
+*****************************************************
+-->
+	<xs:element name="genre" type="genreDefinition"/>
+	<!-- -->
+	<xs:complexType name="genreDefinition">
+		<xs:simpleContent>
+			<xs:extension base="stringPlusLanguagePlusAuthority">
+				<xs:attribute name="type" type="xs:string"/>
+				<xs:attribute name="displayLabel" type="xs:string"/>
+				<xs:attribute name="altRepGroup" type="xs:string"/>
+				<!-- 
+					@usage definition corrected in 3.8.  
+					See "Changes in version 3.8" #13-->
+				<xs:attribute name="usage" type="usagePrimary"/>
+				<!-- 
+****************** following  attribute group added in 3.8 -->
+				<xs:attributeGroup ref="IDAttributeGroup"/>
+				<!--  -->
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<!--
+****************************************************
+*   Top Level Element <identifier>                  *
+*****************************************************
+-->
+	<xs:element name="identifier" type="identifierDefinition"/>
+	<!-- -->
+	<xs:complexType name="identifierDefinition">
+		<xs:simpleContent>
+			<xs:extension base="stringPlusLanguage">
+				<xs:attribute name="displayLabel" type="xs:string"/>
+				<xs:attribute name="type" type="xs:string"/>
+				<xs:attribute name="typeURI" type="xs:anyURI"/>
+				<!-- 
+					@invalid definition corrected in 3.8.  
+					See "Changes in version 3.8" #13-->
+				<xs:attribute name="invalid" type="yes"/>
+				<!-- -->
+				<xs:attribute name="altRepGroup" type="xs:string"/>
+				<!-- 
+****************** following attribute group  added in 3.8 -->
+				<xs:attributeGroup ref="IDAttributeGroup"/>
+				<!-- -->
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<!--  
+****************************************************
+*   Top Level Element <language>                *
+*****************************************************
+-->
+	<xs:element name="language" type="languageDefinition"/>
+	<!-- -->
+	<xs:complexType name="languageDefinition">
+		<xs:sequence>
+			<xs:element ref="languageTerm" maxOccurs="unbounded"/>
+			<xs:element ref="scriptTerm" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="objectPart" type="xs:string"/>
+		<xs:attributeGroup ref="languageAttributeGroup"/>
+		<xs:attribute name="displayLabel" type="xs:string"/>
+		<xs:attribute name="altRepGroup" type="xs:string"/>
+		<!-- 
+					@usage definition corrected in 3.8.  
+					See "Changes in version 3.8" #13-->
+		<xs:attribute name="usage" type="usagePrimary"/>
+		<!-- 
+****************** following attribute group added in 3.8 -->
+		<xs:attributeGroup ref="IDAttributeGroup"/>
+		<!-- -->
+	</xs:complexType>
+	<!--
+
+********   Subordinate Elements for <language>  ********
+
+ 
+*****************languageTerm ************************
+ -->
+	<xs:element name="languageTerm" type="languageTermDefinition"/>
+	<!-- -->
+	<xs:complexType name="languageTermDefinition">
+		<xs:simpleContent>
+			<xs:extension base="stringPlusLanguagePlusAuthority">			  
+	<!--	    ****** changed in 3.8 from "stringPlusLanguage" to
+				****** "stringPlusLanguagePlusAuthority".  Previously,
+				******  @authority was restricted to specific values.
+				******   That restriction is removed in 3.8
+				-->
+				<xs:attribute name="type" type="codeOrText"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<!-- 
+*****************scriptTerm ************************
+-->
+	<xs:element name="scriptTerm" type="scriptTermDefinition"/>
+	<!-- -->
+	<xs:complexType name="scriptTermDefinition">
+		<xs:simpleContent>
+			<xs:extension base="stringPlusLanguagePlusAuthority">
+				<xs:attribute name="type" type="codeOrText"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<!--
+
+****************************************************
+*   Top Level Element <location>                 *
+*****************************************************         
+ -->
+	<xs:element name="location" type="locationDefinition"/>
+	<!-- -->
+	<xs:complexType name="locationDefinition">
+		<xs:sequence>
+			<xs:element ref="physicalLocation" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="shelfLocator" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="url" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="holdingSimple" minOccurs="0"/>
+			<xs:element ref="holdingExternal" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="languageAttributeGroup"/>
+		<xs:attribute name="displayLabel" type="xs:string"/>
+		<xs:attribute name="altRepGroup" type="xs:string"/>
+		<!-- 
+****************** following attribute group  added in 3.8 -->
+		<xs:attributeGroup ref="IDAttributeGroup"/>
+		<!-- -->
+	</xs:complexType>
+	<!--
+
+********   Subordinate Elements for <location>                
+ -->
+	<!--	  
+********** physicalLocation **********         
+-->
+	<xs:element name="physicalLocation" type="physicalLocationDefinition"/>
+	<!-- -->
+	<xs:complexType name="physicalLocationDefinition">
+		<xs:simpleContent>
+			<xs:extension base="stringPlusLanguagePlusAuthority">
+				<xs:attributeGroup ref="xlink:simpleLink"/>
+				<xs:attribute name="displayLabel" type="xs:string"/>
+				<xs:attribute name="type" type="xs:string"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="shelfLocator" type="stringPlusLanguage"/>
+	<!--  
+********** holdingSimple **********      
+ -->
+	<xs:element name="holdingSimple" type="holdingSimpleDefinition"/>
+	<!-- -->
+	<xs:complexType name="holdingSimpleDefinition">
+		<xs:sequence>
+			<xs:element ref="copyInformation" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--
+**********copyInformation **********     
+ -->
+	<xs:element name="copyInformation" type="copyInformationDefinition"/>
+	<!-- -->
+	<xs:complexType name="copyInformationDefinition">
+		<xs:sequence>
+			<xs:element ref="form" minOccurs="0"/>
+			<xs:element ref="subLocation" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="shelfLocator" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="electronicLocator" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="note" minOccurs="0" maxOccurs="unbounded">
+				<xs:complexType>
+					<xs:simpleContent>
+						<xs:extension base="stringPlusLanguage">
+							<xs:attribute name="displayLabel" type="xs:string"/>
+							<xs:attribute name="type" type="xs:string"/>
+							<xs:attributeGroup ref="xlink:simpleLink"/>
+							<!--
+****************** @IDREF added in 3.8 (@ID removed and replaced by the following)-->
+							<xs:attributeGroup ref="IDAttributeGroup"/>
+							<!-- -->
+						</xs:extension>
+					</xs:simpleContent>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="enumerationAndChronology" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="itemIdentifier" minOccurs="0" maxOccurs="unbounded"/>
+			<!--	-->
+		</xs:sequence>
+	</xs:complexType>
+	<!--
+**********itemIdentifier **********     
+ -->
+	<xs:element name="itemIdentifier" type="itemIdentifierDefinition"/>
+	<xs:complexType name="itemIdentifierDefinition">
+		<xs:simpleContent>
+			<xs:extension base="stringPlusLanguage">
+				<xs:attribute name="type" type="xs:string"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<!--
+**********form**********     
+ -->
+	<xs:element name="form" type="formDefinition"/>
+	<!-- -->
+	<xs:complexType name="formDefinition">
+		<xs:simpleContent>
+			<xs:extension base="stringPlusLanguagePlusAuthority">
+				<xs:attribute name="type" type="xs:string"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="subLocation" type="stringPlusLanguage"/>
+	<xs:element name="electronicLocator" type="stringPlusLanguage"/>
+	<!--  
+**********enumerationAndChronology  **********     
+     -->
+	<xs:element name="enumerationAndChronology" type="enumerationAndChronologyDefinition"/>
+	<!-- -->
+	<xs:complexType name="enumerationAndChronologyDefinition">
+		<xs:simpleContent>
+			<xs:extension base="stringPlusLanguage">
+				<xs:attribute name="unitType">
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="1"/>
+							<xs:enumeration value="2"/>
+							<xs:enumeration value="3"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:attribute>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<!--
+ ********** url  **********        
+     -->
+	<xs:element name="url" type="urlDefinition"/>
+	<!-- -->
+	<xs:complexType name="urlDefinition">
+		<xs:simpleContent>
+			<xs:extension base="xs:anyURI">
+				<xs:attribute name="dateLastAccessed" type="xs:string"/>
+				<xs:attribute name="displayLabel" type="xs:string"/>
+				<xs:attribute name="note" type="xs:string"/>
+				<xs:attribute name="access">
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="preview"/>
+							<xs:enumeration value="raw object"/>
+							<xs:enumeration value="object in context"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:attribute>
+				<xs:attribute name="usage">
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="primary display"/>
+							<!-- This value,"primary display”, is deprecated in version 3.8;
+								“primary” is the only value that should be used in 3.8 and beyond.
+								("primary display” remains a legal value in the schema, 
+								for compatibility with earlier versions.) 
+							-->
+							<xs:enumeration value="primary"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:attribute>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="holdingExternal" type="extensionDefinition"/>
+	<!-- 
+****************************************************
+*   Top Level Element <name>                 *
+*****************************************************         
+-->
+	<xs:element name="name" type="nameDefinition"/>
+	<!-- -->
+	<xs:complexType name="nameDefinition">
+		<xs:choice>
+
+			<!-- this choice gives two ways to do this.  
+				The second way allows the element <etal>,  to express "et. al."
+
+Choice one. WITHOUT <etal>.
+-->
+			<xs:choice minOccurs="0" maxOccurs="unbounded">
+				<xs:element ref="namePart"/>
+				<xs:element ref="displayForm"/>
+				<xs:element ref="affiliation"/>
+				<xs:element ref="role"/>
+				<xs:element ref="description"/>
+				<xs:element ref="nameIdentifier"/>
+				<xs:element ref="alternativeName"/>
+				<!--   -->
+			</xs:choice>
+			<!-- 
+Choice two.	With <etal>.
+               The presence of <etal> indicates that there are names that cannot 
+               be explicitily included. It may be empty, or it may have simple content
+               - e.g. <etal>et al.</etal>.  In the latter case the content is what is 
+               suggested for display. 
+               When <etal> occurs:
+                  - <namePart>, <displayForm>, and <identifier> MAY NOT occur;
+                  - <affiliation>, <role>, <description>   MAY occur (but are NOT repeatable).
+              <etal> is not repeatable within a given <name>, however there may be 
+              mutilple <etal> elements, each within in a separate <name> element.
+-->
+			<xs:sequence>
+				<!--   
+             <etal> is mandatory, nonrepeatable, and must occur first. 
+            After that <affiliation>, <role>, and <description> may occur, in any order or number. 
+            <nameIdentifier> is not used with <etal>
+-->
+				<xs:element ref="etal"/>
+				<xs:choice minOccurs="0" maxOccurs="unbounded">
+					<xs:element ref="affiliation"/>
+					<xs:element ref="role"/>
+					<xs:element ref="description"/>
+				</xs:choice>
+			</xs:sequence>
+			<!-- -->
+		</xs:choice>
+		<!--
+****************** @IDREF added in 3.8 (@ID removed and replaced by the following)-->
+		<xs:attributeGroup ref="IDAttributeGroup"/>
+		<!-- -->
+		<xs:attributeGroup ref="authorityAttributeGroup"/>
+		<xs:attributeGroup ref="xlink:simpleLink"/>
+		<xs:attributeGroup ref="languageAttributeGroup"/>
+		<xs:attribute name="displayLabel" type="xs:string"/>
+		<xs:attribute name="altRepGroup" type="xs:string"/>
+		<xs:attribute name="nameTitleGroup" type="xs:string"/>
+		<!-- 
+					@usage definition corrected in 3.8.  
+					See "Changes in version 3.8" #13-->
+		<xs:attribute name="usage" type="usagePrimary"/>
+		<xs:attribute name="type">
+			<xs:simpleType>
+				<xs:restriction base="xs:string">
+					<xs:enumeration value="personal"/>
+					<xs:enumeration value="corporate"/>
+					<xs:enumeration value="conference"/>
+					<xs:enumeration value="family"/>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+		<!--    
+******************  Following line added 11/10/2022.  Fixes a flaw.
+			 -->
+		<xs:attribute name="supplied"  type="yes"/>
+		<!-- -->
+	</xs:complexType>
+	<!--
+
+********   Subordinate Elements for <name>                
+ -->
+	<!-- namePart-->
+	<xs:element name="namePart" type="namePartDefinition"/>
+	<!-- -->
+	<xs:complexType name="namePartDefinition">
+		<xs:simpleContent>
+			<xs:extension base="stringPlusLanguage">
+				<xs:attribute name="type">
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="date"/>
+							<xs:enumeration value="family"/>
+							<xs:enumeration value="given"/>
+							<xs:enumeration value="termsOfAddress"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:attribute>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<!-- displayForm, affiliation, description, alternativeName -->
+	<xs:element name="displayForm" type="stringPlusLanguage"/>
+	<!-- 
+		affiliation definition changed in 3.8. Authority attributes added -->
+	<xs:element name="affiliation" type="stringPlusLanguagePlusAuthority"/>
+	<!-- -->
+	<xs:element name="description" type="stringPlusLanguage"/>
+	<xs:element name="nameIdentifier" type="identifierDefinition"/>
+	<xs:element name="alternativeName" type="alternativeNameDefinition"/>
+	<!--  
+		
+******** role *********************
+    -->
+	<xs:element name="role" type="roleDefinition"/>
+	<!-- -->
+	<xs:complexType name="roleDefinition">
+		<xs:sequence maxOccurs="unbounded">
+			<xs:element ref="roleTerm"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--  
+***************roleTerm *********************** 
+    -->
+	<xs:element name="roleTerm" type="roleTermDefinition"/>
+	<!-- -->
+	<xs:complexType name="roleTermDefinition">
+		<xs:simpleContent>
+			<xs:extension base="stringPlusLanguagePlusAuthority">
+				<xs:attribute name="type" type="codeOrText"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<!-- 
+********  etal  ********
+-->
+	<xs:element name="etal" type="stringPlusLanguage"/>
+	<!--   
+********  alternativeName  ********
+-->
+	<xs:complexType name="alternativeNameDefinition">
+
+		<xs:choice minOccurs="0" maxOccurs="unbounded">
+			<xs:element ref="namePart"/>
+			<xs:element ref="displayForm"/>
+			<xs:element ref="affiliation"/>
+			<xs:element ref="role"/>
+			<xs:element ref="description"/>
+			<xs:element ref="nameIdentifier"/>
+		</xs:choice>
+		<!-- -->
+		<xs:attributeGroup ref="xlink:simpleLink"/>
+		<xs:attributeGroup ref="languageAttributeGroup"/>
+		<xs:attribute name="displayLabel" type="xs:string"/>
+		<xs:attribute name="altType" type="xs:string"/>
+	</xs:complexType>
+
+	<!--
+
+****************************************************
+*   Top Level Element <note>                      *
+*****************************************************         
+-->
+	<xs:element name="note" type="noteDefinition"/>
+	<!-- -->
+	<xs:complexType name="noteDefinition">
+		<xs:simpleContent>
+			<xs:extension base="stringPlusLanguage">
+				<xs:attribute name="displayLabel" type="xs:string"/>
+				<xs:attribute name="type" type="xs:string"/>
+				<xs:attribute name="typeURI" type="xs:anyURI"/>
+				<xs:attributeGroup ref="xlink:simpleLink"/>
+				<!--
+****************** @IDREF added in 3.8 (@ID removed and replaced by the following)-->
+				<xs:attributeGroup ref="IDAttributeGroup"/>
+				<!-- -->
+				<xs:attribute name="altRepGroup" type="xs:string"/>
+				<!-- -->
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<!--  
+
+****************************************************
+*   Top Level Element <originInfo>                 *
+****************************************************        
+-->
+	<xs:element name="originInfo" type="originInfoDefinition"/>
+	<!-- -->
+	<xs:complexType name="originInfoDefinition">
+		<xs:choice maxOccurs="unbounded">
+			<xs:element ref="place"/>
+			<xs:element ref="publisher"/>
+			<xs:element ref="dateIssued"/>
+			<xs:element ref="dateCreated"/>
+			<xs:element ref="dateCaptured"/>
+			<xs:element ref="dateValid"/>
+			<xs:element ref="dateModified"/>
+			<xs:element ref="copyrightDate"/>
+			<xs:element ref="dateOther"/>
+			<!-- 
+				following element, "displayDate", added in 3.8  -->
+			<xs:element ref="displayDate"/>
+			<!--  -->
+			<xs:element ref="edition"/>
+			<xs:element ref="issuance"/>
+			<xs:element ref="frequency"/>
+			<!--  
+				following element, "agent", added in 3.8-->
+			<xs:element ref="agent"/>
+			<!--		-->
+		</xs:choice>
+		<xs:attributeGroup ref="languageAttributeGroup"/>
+		<xs:attribute name="displayLabel" type="xs:string"/>
+		<xs:attribute name="altRepGroup" type="xs:string"/>
+		<xs:attribute name="eventType" type="xs:string"/>
+		<!--  
+			following attribute, @eventTypeURI, added in 3.8	-->
+		<xs:attribute name="eventTypeURI" type="xs:anyURI"/>
+		<!--
+******************  following attribute group added in 3.8 -->
+		<xs:attributeGroup ref="IDAttributeGroup"/>
+		<!-- -->
+	</xs:complexType>
+	<!--
+
+********   Subordinate Elements for <originInfo>    -->             
+<!--
+		
+*** place ***
+-->
+	<xs:element name="place" type="placeDefinition"/>
+	<!-- -->
+	<xs:complexType name="placeDefinition">
+		<xs:choice minOccurs="1" maxOccurs="unbounded">
+			<!-- 
+				Previously, place was simply one or more occurrences of placeTerm.
+				In 3.8, placeIdentifer and cartographics are added to placeDefinition. 
+				placeIdentifier is a new element in 3.8; cartographics uses the 
+				existing cartographicsDefinition. 
+				
+				So, now place is one or more of the following three subelements where 
+				each may be any of the three.
+			-->
+			<xs:element ref="placeTerm"/>
+			<xs:element ref="placeIdentifier"/>
+			<xs:element ref="cartographics"/>
+			<!-- -->
+		</xs:choice>
+		<!-- 
+					@supplied definition corrected in 3.8.  
+					See "Changes in version 3.8" #13 -->
+		<xs:attribute name="supplied" type="yes"/>
+		<!-- -->
+	</xs:complexType>
+	<!-- 
+		
+*** placeTerm ***
+-->
+	<xs:element name="placeTerm" type="placeTermDefinition"/>
+	<!-- -->
+	<xs:complexType name="placeTermDefinition">
+		<xs:simpleContent>
+			<xs:extension base="stringPlusLanguagePlusAuthority">
+				<!--  
+				****** changed in 3.8 from "stringPlusLanguage" to
+				****** "stringPlusLanguagePlusAuthority".  Previously,
+				******  @authority was restricted to specific values.
+				******   That restriction is removed in 3.8
+				-->
+				<xs:attribute name="type" type="codeOrText"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<!-- 
+		
+*** placeIdentifier ***    (********new in 3.8) 
+-->
+	<xs:element name="placeIdentifier" type="xs:anyURI"/>
+	<!-- -->
+	<!-- 
+		
+*** publisher ***
+-->
+	<xs:element name="publisher" type="publisherDefinition"/>
+	<!--   -->
+	<xs:complexType name="publisherDefinition">
+		<xs:simpleContent>
+			<xs:extension base="stringPlusLanguagePlusSupplied">
+				<xs:attributeGroup ref="authorityAttributeGroup"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<!--
+		
+	agent ***    (********new in 3.8) 
+		
+	 -->
+	<xs:element name="agent" type="nameDefinition"/>
+	<!-- 
+		
+********** dates  **********  -->
+	<xs:element name="dateIssued" type="dateDefinition"/>
+	<xs:element name="dateCreated" type="dateDefinition"/>
+	<xs:element name="dateCaptured" type="dateDefinition"/>
+	<xs:element name="dateValid" type="dateDefinition"/>
+	<xs:element name="dateModified" type="dateDefinition"/>
+	<xs:element name="copyrightDate" type="dateDefinition"/>
+	<xs:element name="dateOther" type="dateOtherDefinition"/>
+
+	<!-- following definition added 3.8  -->
+	<xs:element name="displayDate" type="xs:string"/>
+	<!--  -->
+
+	<xs:complexType name="dateDefinition">
+		<xs:simpleContent>
+			<xs:extension base="stringPlusLanguage">
+				<xs:attribute name="encoding">
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="w3cdtf"/>
+							<xs:enumeration value="iso8601"/>
+							<xs:enumeration value="marc"/>
+							<xs:enumeration value="temper"/>
+							<xs:enumeration value="edtf"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:attribute>
+				<xs:attribute name="qualifier">
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="approximate"/>
+							<xs:enumeration value="inferred"/>
+							<xs:enumeration value="questionable"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:attribute>
+				<xs:attribute name="point">
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="start"/>
+							<xs:enumeration value="end"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:attribute>
+				<!-- 
+					@keyDate definition corrected in 3.8.  
+					See "Changes in version 3.8" #13-->
+				<xs:attribute name="keyDate" type="yes"/>
+				<!-- -->
+				<xs:attribute name="calendar" type="xs:string"/>
+				<!-- -->
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<!--
+	********** dateOther  **********  
+-->
+	<xs:complexType name="dateOtherDefinition">
+		<xs:simpleContent>
+			<xs:extension base="dateDefinition">
+				<xs:attribute name="type" type="xs:string"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<!--
+	********** edition **********  
+-->
+	<xs:element name="edition" type="stringPlusLanguagePlusSupplied"/>
+	<!--  
+********** issuance **********  	
+       -->
+	<xs:element name="issuance" type="issuanceDefinition"/>
+	<!-- -->
+	<xs:simpleType name="issuanceDefinition">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="continuing"/>
+			<xs:enumeration value="monographic"/>
+			<xs:enumeration value="single unit"/>
+			<xs:enumeration value="multipart monograph"/>
+			<xs:enumeration value="serial"/>
+			<xs:enumeration value="integrating resource"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!--
+	********** frequency **********  
+-->
+	<xs:element name="frequency" type="stringPlusLanguagePlusAuthority"/>
+
+
+	<!--
+****************************************************
+*   Top Level Element <part>                       *
+*****************************************************  
+-->
+	<xs:element name="part" type="partDefinition"/>
+	<!-- -->
+	<xs:complexType name="partDefinition">
+		<xs:choice minOccurs="0" maxOccurs="unbounded">
+			<xs:element ref="detail"/>
+			<xs:element name="extent" type="extentDefinition"/>
+			<xs:element ref="date"/>
+			<xs:element ref="text"/>
+		</xs:choice>
+		<xs:attribute name="type" type="xs:string"/>
+		<xs:attribute name="order" type="xs:integer"/>
+		<xs:attributeGroup ref="languageAttributeGroup"/>
+		<xs:attribute name="displayLabel" type="xs:string"/>
+		<xs:attribute name="altRepGroup" type="xs:string"/>
+		<!--
+****************** @IDREF added in 3.8 (@ID removed and replaced by the following)-->
+		<xs:attributeGroup ref="IDAttributeGroup"/>
+		<!-- -->
+	</xs:complexType>
+	<!--
+
+********   Subordinate Elements for <part>                
+ -->
+	<!-- 
+********** detail **********  
+-->
+	<xs:element name="detail" type="detailDefinition"/>
+	<!-- -->
+	<xs:complexType name="detailDefinition">
+		<xs:choice maxOccurs="unbounded">
+			<xs:element ref="number"/>
+			<xs:element ref="caption"/>
+			<xs:element ref="title"/>
+		</xs:choice>
+		<xs:attribute name="type" type="xs:string"/>
+		<xs:attribute name="level" type="xs:positiveInteger"/>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="number" type="stringPlusLanguage"/>
+	<xs:element name="caption" type="stringPlusLanguage"/>
+	<!-- 
+********** extent **********  
+-->
+	<xs:complexType name="extentDefinition">
+		<xs:sequence>
+			<xs:element ref="start" minOccurs="0"/>
+			<xs:element ref="end" minOccurs="0"/>
+			<xs:element ref="total" minOccurs="0"/>
+			<xs:element ref="list" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="unit" type="xs:string"/>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="start" type="stringPlusLanguage"/>
+	<xs:element name="end" type="stringPlusLanguage"/>
+	<xs:element name="total" type="xs:positiveInteger"/>
+	<xs:element name="list" type="stringPlusLanguage"/>
+	<!--
+***************** date *** 
+-->
+	<xs:element name="date" type="dateDefinition"/>
+	<!--
+***************** text *** 
+-->
+	<xs:element name="text">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="stringPlusLanguage">
+					<xs:attribute name="displayLabel" type="xs:string"/>
+					<xs:attribute name="type" type="xs:string"/>
+					<xs:attributeGroup ref="xlink:simpleLink"/>
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<!--
+
+****************************************************
+*   Top Level Element <physicalDescription> *
+*****************************************************         
+ -->
+	<xs:element name="physicalDescription" type="physicalDescriptionDefinition"/>
+	<!-- -->
+	<xs:complexType name="physicalDescriptionDefinition">
+		<xs:choice maxOccurs="unbounded">
+			<xs:element ref="form"/>
+			<!-- same definition as is used in copyInformation -->
+			<xs:element ref="reformattingQuality"/>
+			<xs:element ref="internetMediaType"/>
+			<xs:element ref="extent"/>
+			<xs:element ref="digitalOrigin"/>
+			<xs:element name="note" type="physicalDescriptionNote"/>
+		</xs:choice>
+		<xs:attributeGroup ref="languageAttributeGroup"/>
+		<xs:attribute name="displayLabel" type="xs:string"/>
+		<xs:attribute name="altRepGroup" type="xs:string"/>
+		<!-- 
+******************  following attribute group added in in 3.8-->
+		<xs:attributeGroup ref="IDAttributeGroup"/>
+		<!-- -->
+	</xs:complexType>
+	<!--
+
+********   Subordinate Elements for <physicalDescription>                
+ -->
+	<!-- 
+**********reformattingQuality **********  		 
+ -->
+	<xs:element name="reformattingQuality" type="reformattingQualityDefinition"/>
+	<!-- -->
+	<xs:simpleType name="reformattingQualityDefinition">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="access"/>
+			<xs:enumeration value="preservation"/>
+			<xs:enumeration value="replacement"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!-- 
+**********internetMediaType **********  		 
+ -->
+	<xs:element name="internetMediaType" type="stringPlusLanguage"/>
+	<!--
+********** extent **********  	
+ -->
+	<xs:element name="extent">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="stringPlusLanguagePlusSupplied">
+					<xs:attribute name="unit"/>
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<!--
+********** digitalOrigin **********  	
+ -->
+	<xs:element name="digitalOrigin" type="digitalOriginDefinition"/>
+	<!-- -->
+	<xs:simpleType name="digitalOriginDefinition">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="born digital"/>
+			<xs:enumeration value="reformatted digital"/>
+			<xs:enumeration value="digitized microfilm"/>
+			<xs:enumeration value="digitized other analog"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!--
+********** note **********  	
+ -->
+	<xs:complexType name="physicalDescriptionNote">
+		<xs:simpleContent>
+			<xs:extension base="stringPlusLanguage">
+				<xs:attribute name="displayLabel" type="xs:string"/>
+				<xs:attribute name="type" type="xs:string"/>
+				<xs:attribute name="typeURI" type="xs:anyURI"/>
+				<xs:attributeGroup ref="xlink:simpleLink"/>
+				<!--
+****************** @IDREF added in 3.8 (@ID removed and replaced by the following)-->
+				<xs:attributeGroup ref="IDAttributeGroup"/>
+				<!-- -->
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<!--
+****************************************************
+*   Top Level Element <recordInfo>              *
+*****************************************************         
+
+**********  recordInfo  **********   
+-->
+	<xs:element name="recordInfo" type="recordInfoDefinition"/>
+	<!-- -->
+	<xs:complexType name="recordInfoDefinition">
+		<xs:choice maxOccurs="unbounded">
+			<xs:element ref="recordContentSource"/>
+			<xs:element ref="recordCreationDate"/>
+			<xs:element ref="recordChangeDate"/>
+			<xs:element ref="recordIdentifier"/>
+			<xs:element ref="languageOfCataloging"/>
+			<xs:element ref="recordOrigin"/>
+			<xs:element ref="descriptionStandard"/>
+			<xs:element ref="recordInfoNote"/>
+			<!-- -->
+		</xs:choice>
+		<xs:attributeGroup ref="languageAttributeGroup"/>
+		<xs:attribute name="displayLabel" type="xs:string"/>
+		<xs:attribute name="altRepGroup" type="xs:string"/>
+		<!-- 
+					@usage added to recordInfo in 3.8.  -->
+		<xs:attribute name="usage" type="usagePrimary"/>
+		<!--
+****************** @IDREF added in 3.8 (@ID removed and replaced by the following) -->
+		<xs:attributeGroup ref="IDAttributeGroup"/>
+		<!-- -->
+	</xs:complexType>
+	<!--
+
+********   Subordinate Elements for <recordInfo>                
+ -->
+	<xs:element name="recordContentSource" type="stringPlusLanguagePlusAuthority"/>
+	<xs:element name="recordCreationDate" type="dateDefinition"/>
+	<xs:element name="recordChangeDate" type="dateDefinition"/>
+	<xs:element name="recordInfoNote" type="noteDefinition"/>
+	<!--
+********** recordIdentifier 
+-->
+	<xs:element name="recordIdentifier" type="recordIdentifierDefinition"/>
+	<!-- -->
+	<xs:complexType name="recordIdentifierDefinition">
+		<xs:simpleContent>
+			<xs:extension base="stringPlusLanguage">
+				<xs:attribute name="source" type="xs:string"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="languageOfCataloging" type="languageDefinition"/>
+	<xs:element name="recordOrigin" type="stringPlusLanguage"/>
+	<xs:element name="descriptionStandard" type="stringPlusLanguagePlusAuthority"/>
+	<!-- 
+
+****************************************************
+*   Top Level Element <relatedItem>             *
+*****************************************************         
+
+**********   relatedItem  **********  
+-->
+	<xs:element name="relatedItem" type="relatedItemDefinition"/>
+	<!-- -->
+	<xs:complexType name="relatedItemDefinition">
+		<xs:group ref="modsGroup" minOccurs="0" maxOccurs="unbounded"/>
+		<xs:attribute name="type">
+			<xs:simpleType>
+				<xs:restriction base="xs:string">
+					<xs:enumeration value="preceding"/>
+					<xs:enumeration value="succeeding"/>
+					<xs:enumeration value="original"/>
+					<xs:enumeration value="host"/>
+					<xs:enumeration value="constituent"/>
+					<xs:enumeration value="series"/>
+					<xs:enumeration value="otherVersion"/>
+					<xs:enumeration value="otherFormat"/>
+					<xs:enumeration value="isReferencedBy"/>
+					<xs:enumeration value="references"/>
+					<xs:enumeration value="reviewOf"/>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+		<!-- -->
+		<xs:attribute name="otherType" type="xs:string"/>
+		<xs:attribute name="otherTypeAuth" type="xs:string"/>
+		<xs:attribute name="otherTypeAuthURI" type="xs:string"/>
+		<xs:attribute name="otherTypeURI" type="xs:string"/>
+		<xs:attribute name="displayLabel" type="xs:string"/>
+		<xs:attributeGroup ref="xlink:simpleLink"/>
+		<!--
+****************** @IDREF added in 3.8 (@ID removed and replaced by the following)-->
+		<xs:attributeGroup ref="IDAttributeGroup"/>
+		<!-- -->
+	</xs:complexType>
+	<!--  
+
+****************************************************
+*   Top Level Element <subject>                  *
+*****************************************************         
+-->
+	<xs:element name="subject" type="subjectDefinition"/>
+	<!-- -->
+	<xs:complexType name="subjectDefinition">
+		<xs:choice minOccurs="0" maxOccurs="unbounded">
+			<xs:element ref="topic"/>
+			<xs:element ref="geographic"/>
+			<xs:element ref="temporal"/>
+			<xs:element name="titleInfo" type="subjectTitleInfoDefinition"/>
+			<xs:element name="name" type="subjectNameDefinition"/>
+			<xs:element ref="geographicCode"/>
+			<xs:element ref="hierarchicalGeographic"/>
+			<xs:element ref="cartographics"/>
+			<xs:element ref="occupation"/>
+			<xs:element ref="genre"/>
+			<!-- uses top-level genre definition -->
+		</xs:choice>
+		<xs:attributeGroup ref="authorityAttributeGroup"/>
+		<xs:attributeGroup ref="languageAttributeGroup"/>
+		<xs:attributeGroup ref="xlink:simpleLink"/>
+		<xs:attribute name="displayLabel" type="xs:string"/>
+		<xs:attribute name="altRepGroup" type="xs:string"/>
+		<!-- 
+****************** @IDREF added in 3.8 (@ID removed and replaced by the following)-->
+		<xs:attributeGroup ref="IDAttributeGroup"/>
+		<!-- -->
+		<!-- 
+					@usage definition corrected in 3.8.  
+					See "Changes in version 3.8" #13-->
+		<xs:attribute name="usage" type="usagePrimary"/>
+	</xs:complexType>
+	<!--
+
+********   Subordinate Elements for <subject>                
+ -->
+	<!-- topic, geographic -->
+	<xs:element name="topic" type="stringPlusLanguagePlusAuthority"/>
+	<xs:element name="geographic" type="stringPlusLanguagePlusAuthority"/>
+	<xs:element name="geographicCode" type="stringPlusLanguagePlusAuthority"/>
+	<!-- changed in 3.8 from "geographicCodeDefinition" to "stringPlusLanguagePlusAuthority". 
+		Previously there had been a separate definition for geographicCode 
+		to accomodate a controlled list restriction.  That restriction is 
+		dropped in 3.8 
+		-->
+	<!-- 
+*****************temporal  ************************
+ -->
+	<xs:element name="temporal" type="temporalDefinition"/>
+	<!-- -->
+	<xs:complexType name="temporalDefinition">
+		<xs:simpleContent>
+			<xs:extension base="dateDefinition">
+				<xs:attributeGroup ref="authorityAttributeGroup"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<!-- 
+*****************subjectTitleInfo ************************
+-->
+	<xs:complexType name="subjectTitleInfoDefinition">
+		<xs:choice minOccurs="0" maxOccurs="unbounded">
+			<xs:element ref="title"/>
+			<xs:element ref="subTitle"/>
+			<xs:element ref="partNumber"/>
+			<xs:element ref="partName"/>
+			<xs:element ref="nonSort"/>
+		</xs:choice>
+		<!--
+****************** @IDREF added in 3.8 (@ID removed and replaced by the following)-->
+		<xs:attributeGroup ref="IDAttributeGroup"/>
+		<!-- -->
+		<xs:attributeGroup ref="authorityAttributeGroup"/>
+		<xs:attributeGroup ref="xlink:simpleLink"/>
+		<xs:attributeGroup ref="languageAttributeGroup"/>
+		<xs:attribute name="displayLabel" type="xs:string"/>
+		<xs:attribute name="type">
+			<xs:simpleType>
+				<xs:restriction base="xs:string">
+					<xs:enumeration value="abbreviated"/>
+					<xs:enumeration value="translated"/>
+					<xs:enumeration value="alternative"/>
+					<xs:enumeration value="uniform"/>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+		<!--	
+					Following four attributes added in 3.8 -->
+		<xs:attribute name="otherType"/>
+		<xs:attribute name="otherTypeAuth" type="xs:string"/>
+		<xs:attribute name="otherTypeAuthURI" type="xs:anyURI"/>
+		<xs:attribute name="otherTypeURI" type="xs:anyURI"/>
+		<!-- -->
+	</xs:complexType>
+	<!-- 
+*****************subjectName ************************
+-->
+	<xs:complexType name="subjectNameDefinition">
+		<xs:choice minOccurs="0" maxOccurs="unbounded">
+			<xs:element ref="namePart"/>
+			<xs:element ref="displayForm"/>
+			<xs:element ref="affiliation"/>
+			<xs:element ref="role"/>
+			<xs:element ref="description"/>
+			<xs:element ref="nameIdentifier"/>
+			<!-- -->
+		</xs:choice>
+		<xs:attribute name="type">
+			<xs:simpleType>
+				<xs:restriction base="xs:string">
+					<xs:enumeration value="personal"/>
+					<xs:enumeration value="corporate"/>
+					<xs:enumeration value="conference"/>
+					<xs:enumeration value="family"/>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+		<!--
+****************** @IDREF added in 3.8 (@ID removed and replaced by the following)-->
+		<xs:attributeGroup ref="IDAttributeGroup"/>
+		<!-- -->
+		<xs:attributeGroup ref="authorityAttributeGroup"/>
+		<xs:attributeGroup ref="xlink:simpleLink"/>
+		<xs:attributeGroup ref="languageAttributeGroup"/>
+		<xs:attribute name="displayLabel" type="xs:string"/>
+	</xs:complexType>
+	<!--
+ ********** geographicCode ********** 
+ 
+ "geographicCode definition, here, prior to 3.8, is removed in 3.8;
+ it is now in "subordinate defitions for subject"
+-->
+	<!--  
+********** hierarchicalGeographic **********  	 
+-->
+	<xs:element name="hierarchicalGeographic" type="hierarchicalGeographicDefinition"/>
+	<!-- -->
+	<xs:complexType name="hierarchicalGeographicDefinition">
+		<xs:choice maxOccurs="unbounded">
+			<xs:element ref="extraTerrestrialArea"/>
+			<xs:element ref="continent"/>
+			<xs:element ref="country"/>
+			<!-- -->
+			<xs:element ref="province"/>
+			<!-- province has been deprecated (in a previous version). 
+				Use <state> instead of province. 
+			-->
+			<xs:element ref="region"/>
+			<xs:element ref="state"/>
+			<xs:element ref="territory"/>
+			<xs:element ref="county"/>
+			<xs:element ref="city"/>
+			<xs:element ref="citySection"/>
+			<xs:element ref="island"/>
+			<xs:element ref="area"/>
+		</xs:choice>
+		<xs:attributeGroup ref="authorityAttributeGroup"/>
+	</xs:complexType>
+	<!-- -->
+	<!-- 		********** hierarchicalPart   *** auxiliary definition 	-->
+	<xs:complexType name="hierarchicalPart">
+		<xs:simpleContent>
+			<xs:extension base="stringPlusLanguage">
+				<xs:attribute name="level"/>
+				<xs:attribute name="period"/>
+				<xs:attributeGroup ref="authorityAttributeGroup"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<!-- 
+		Next, definitions for the place elements, starting with area, region, and citySection
+		-->
+	<!--
+		
+********** area 
+-->
+	<xs:element name="area" type="areaDefinition"/>
+	<!-- -->
+	<xs:complexType name="areaDefinition">
+		<xs:simpleContent>
+			<xs:extension base="hierarchicalPart">
+				<xs:attribute name="areaType"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<!-- -->
+	<!--
+		
+********** region 
+-->
+	<xs:element name="region" type="regionDefinition"/>
+	<!-- -->
+	<xs:complexType name="regionDefinition">
+		<xs:simpleContent>
+			<xs:extension base="hierarchicalPart">
+				<xs:attribute name="regionType"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<!--
+		
+********** citySection
+-->
+	<xs:element name="citySection" type="citySectionDefinition"/>
+	<!-- -->
+	<xs:complexType name="citySectionDefinition">
+		<xs:simpleContent>
+			<xs:extension base="hierarchicalPart">
+				<xs:attribute name="citySectionType"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<!--  -->	
+	<!-- 
+		Next, definitions for state
+		-->
+	<!--
+		
+********** state
+-->
+	<xs:element name="state" type="stateDefinition"/>
+	<!-- see stateDefinition, revised in 3.8: @stateType added.  -->
+	<!-- 
+		
+	The rest are all of type "hierarchicalPart"   ......
+		-->
+	<xs:element name="extraTerrestrialArea" type="hierarchicalPart"/>
+	<xs:element name="city" type="hierarchicalPart"/>
+	<xs:element name="continent" type="hierarchicalPart"/>
+	<xs:element name="country" type="hierarchicalPart"/>
+	<xs:element name="county" type="hierarchicalPart"/>
+	<xs:element name="island" type="hierarchicalPart"/>
+	<!-- 
+		following removed in 3.8, replaced by new definition for state, below.
+	****REMOVED: <xs:element name="state" type="hierarchicalPart"/>  ****REMOVED
+	-->
+	<xs:element name="territory" type="hierarchicalPart"/>
+	<!--  
+		..... except for province  (which was depricated in a previous version)	-->
+	<xs:element name="province" type="stringPlusLanguage"/>
+	<!-- 	
+		.... and (in 3.8) for state: 
+	
+	new state definition, 3.8. Before, state was simply hierarchicalPart.
+	 Now @stateType is added-->
+	<xs:complexType name="stateDefinition">
+		<xs:simpleContent>
+			<xs:extension base="hierarchicalPart">
+				<xs:attribute name="stateType"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<!--  
+		
+ ********** cartographics **********  
+-->
+	<xs:element name="cartographics" type="cartographicsDefinition"/>
+	<!-- -->
+	<xs:complexType name="cartographicsDefinition">
+
+		<xs:sequence>
+			<xs:element ref="scale" minOccurs="0"/>
+			<xs:element ref="projection" minOccurs="0"/>
+			<xs:element ref="coordinates" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="cartographicExtension" minOccurs="0" maxOccurs="unbounded"/>
+			<!--  -->
+		</xs:sequence>
+		<!--  -->
+		<xs:attributeGroup ref="authorityAttributeGroup"/>
+		<!--  -->
+	</xs:complexType>
+	<!-- -->
+	<xs:element name="scale" type="stringPlusLanguage"/>
+	<xs:element name="projection" type="stringPlusLanguage"/>
+	<xs:element name="coordinates" type="stringPlusLanguage"/>
+	<xs:element name="cartographicExtension" type="extensionDefinition"/>
+	<!-- 
+		
+ ********** occupation **********  
+-->
+	<xs:element name="occupation" type="stringPlusLanguagePlusAuthority"/>
+	<!--
+****************************************************
+*   Top Level Element <tableOfContents>     *
+*****************************************************           
+ -->
+	<xs:element name="tableOfContents" type="tableOfContentsDefinition"/>
+	<!-- -->
+	<xs:complexType name="tableOfContentsDefinition">
+		<xs:simpleContent>
+			<xs:extension base="stringPlusLanguage">
+				<xs:attribute name="displayLabel" type="xs:string"/>
+				<xs:attribute name="type" type="xs:string"/>
+				<xs:attributeGroup ref="xlink:simpleLink"/>
+				<!-- 
+					@sharable definition corrected in 3.8.  
+					See "Changes in version 3.8" #13-->
+				<xs:attribute name="shareable" type="no"/>
+				<!--  -->
+				<xs:attribute name="altRepGroup" type="xs:string"/>
+				<xs:attributeGroup ref="altFormatAttributeGroup"/>
+				<!--
+****************** @IDREF added in 3.8 (@ID removed and replaced by the following)-->
+				<xs:attributeGroup ref="IDAttributeGroup"/>
+				<!-- -->
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<!-- 
+
+****************************************************
+*   Top Level Element <targetAudience>       *
+*****************************************************           
+ -->
+	<xs:element name="targetAudience" type="targetAudienceDefinition"/>
+	<!-- -->
+	<xs:complexType name="targetAudienceDefinition">
+		<xs:simpleContent>
+			<xs:extension base="stringPlusLanguagePlusAuthority">
+				<xs:attribute name="displayLabel" type="xs:string"/>
+				<xs:attribute name="altRepGroup" type="xs:string"/>
+				<!-- 
+******************  following attribute group added in 3.8-->
+				<xs:attributeGroup ref="IDAttributeGroup"/>
+				<!-- -->
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<!--
+****************************************************
+*   Top Level Element <titleInfo>                   *
+*****************************************************
+          -->
+	<xs:element name="titleInfo" type="titleInfoDefinition"/>
+	<!-- -->
+	<xs:complexType name="titleInfoDefinition">
+		<xs:choice minOccurs="0" maxOccurs="unbounded">
+			<xs:element ref="title"/>
+			<xs:element ref="subTitle"/>
+			<xs:element ref="partNumber"/>
+			<xs:element ref="partName"/>
+			<xs:element ref="nonSort"/>
+		</xs:choice>
+		<xs:attribute name="type">
+			<xs:simpleType>
+				<xs:restriction base="xs:string">
+					<xs:enumeration value="abbreviated"/>
+					<xs:enumeration value="translated"/>
+					<xs:enumeration value="alternative"/>
+					<xs:enumeration value="uniform"/>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+		<xs:attribute name="otherType"/>
+		<!-- 
+			Following three attributes added in 3.8 
+			(For consistency with relatedItem.)
+			-->
+		<xs:attribute name="otherTypeAuth" type="xs:string"/>
+		<xs:attribute name="otherTypeAuthURI" type="xs:anyURI"/>
+		<xs:attribute name="otherTypeURI" type="xs:anyURI"/>
+		<!--  -->
+		<!-- 
+					@supplied definition corrected in 3.8.  
+					See "Changes in version 3.8" #13-->
+		<xs:attribute name="supplied" type="yes"/>
+		<!-- -->
+		<xs:attribute name="altRepGroup" type="xs:string"/>
+		<xs:attributeGroup ref="altFormatAttributeGroup"/>
+		<xs:attribute name="nameTitleGroup" type="xs:string"/>
+		<!-- 
+					@usage definition corrected in 3.8.  
+					See "Changes in version 3.8" #13-->
+		<xs:attribute name="usage" type="usagePrimary"/>
+		<!-- -->
+		<xs:attributeGroup ref="authorityAttributeGroup"/>
+		<xs:attributeGroup ref="xlink:simpleLink"/>
+		<xs:attributeGroup ref="languageAttributeGroup"/>
+		<xs:attribute name="displayLabel" type="xs:string"/>
+		<!--
+****************** @IDREF added in 3.8 (@ID removed and replaced by the following)-->
+		<xs:attributeGroup ref="IDAttributeGroup"/>
+		<!-- -->
+	</xs:complexType>
+	<!--
+
+********   Subordinate Elements for <titleInfo>                
+ -->
+	<xs:element name="title" type="stringPlusLanguage"/>
+	<xs:element name="subTitle" type="stringPlusLanguage"/>
+	<xs:element name="partNumber" type="stringPlusLanguage"/>
+	<xs:element name="partName" type="stringPlusLanguage"/>
+	<!-- 
+*********  nonSort
+		-->
+	<xs:element name="nonSort">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="stringPlusLanguage">
+					<xs:attribute ref="xml:space"/>
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<!--
+****************************************************
+*   Top Level Element <typeOfResource>     *
+*****************************************************         
+ -->
+	<xs:element name="typeOfResource" type="typeOfResourceDefinition"/>
+	<!-- -->
+	<xs:complexType name="typeOfResourceDefinition">
+		<xs:simpleContent>
+			<xs:extension base="stringPlusLanguagePlusAuthority">
+				<!-- 
+
+					@collection, @manuscript, and @usage definitions changed.  
+					See "Changes in version 3.8" #13-->
+				<xs:attribute name="collection" type="yes"/>
+				<xs:attribute name="manuscript" type="yes"/>
+				<xs:attribute name="usage" type="usagePrimary"/>
+				<!-- -->
+				<xs:attribute name="displayLabel" type="xs:string"/>
+				<xs:attribute name="altRepGroup" type="xs:string"/>
+				<!-- 
+******************  following attribute group added in 3.8-->
+				<xs:attributeGroup ref="IDAttributeGroup"/>
+				<!-- -->
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+
+	<!--  
+		
+		***** End of top level elements *****
+		
+         *********************************
+         *********************************
+         Part 3:   Auxiliary definitions
+         *********************************
+         *********************************
+
+**********************************
+String Definitions 
+**********************************
+-->
+	<!--
+********** stringPlusLanguage  
+   -->
+	<xs:complexType name="stringPlusLanguage">
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:attributeGroup ref="languageAttributeGroup"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<!--
+************************* stringPlusLanguagePlusAuthority  *************************     	
+ -->
+	<xs:complexType name="stringPlusLanguagePlusAuthority">
+		<xs:simpleContent>
+			<xs:extension base="stringPlusLanguage">
+				<xs:attributeGroup ref="authorityAttributeGroup"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<!--                     
+************************* stringPlusLanguagePlusSupplied  *************************     	 
+ -->
+	<xs:complexType name="stringPlusLanguagePlusSupplied">
+		<xs:simpleContent>
+			<xs:extension base="stringPlusLanguage">
+				<xs:attribute name="supplied" type="yes"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<!-- 
+**********************************
+  Attribute Group Definitions 
+**********************************
+-->
+	<!--   
+ ********** authorityAttributeGroup   **********  	                       	  
+   -->
+	<xs:attributeGroup name="authorityAttributeGroup">
+		<!-- new in 3.4 -->
+		<xs:attribute name="authority" type="xs:string"/>
+		<xs:attribute name="authorityURI" type="xs:anyURI"/>
+		<xs:attribute name="valueURI" type="xs:anyURI"/>
+	</xs:attributeGroup>
+	<!--   
+  ********** languageAttributeGroup   **********  	                       	  
+-->
+	<xs:attributeGroup name="languageAttributeGroup">
+		<xs:attribute name="lang" type="xs:string"/>
+		<xs:attribute ref="xml:lang"/>
+		<xs:attribute name="script" type="xs:string"/>
+		<xs:attribute name="transliteration" type="xs:string"/>
+	</xs:attributeGroup>
+	<!--   
+  ********** altFormatAttributeGroup   **********  	                       	  
+-->
+	<xs:attributeGroup name="altFormatAttributeGroup">
+		<xs:attribute name="altFormat" type="xs:anyURI"/>
+		<xs:attribute name="contentType" type="xs:string"/>
+	</xs:attributeGroup>
+
+	<!--   ********** IDAttributeGroup   **********  	                       	  
+-
+			This attribute group added in 3.8 
+			-->
+	<xs:attributeGroup name="IDAttributeGroup">
+		<xs:attribute name="ID" type="xs:ID"/>
+		<xs:attribute name="IDREF" type="xs:IDREF"/>
+	</xs:attributeGroup>
+	<!-- 
+****************************************************
+  - Attribute definitions (simpleTypes)
+*****************************************************
+-->
+	<!--  
+   ********** codeOrText
+                  ******** used by type attribute  for elements that distinguish code from text:
+                  ******** <languageTerm>, <placeTerm>, <roleTerm>, <scriptTerm>
+ -->
+	<xs:simpleType name="codeOrText">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="code"/>
+			<xs:enumeration value="text"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!-- 
+		all following attribute definitions added 3.8	
+	-->
+	<xs:simpleType name="no">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="no"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!-- -->
+	<xs:simpleType name="yes">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="yes"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!-- -->
+	<xs:simpleType name="usagePrimary">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="primary"/>
+		</xs:restriction>
+	</xs:simpleType>
+
+</xs:schema>

--- a/a3m/client/assets/mods/xml.xsd
+++ b/a3m/client/assets/mods/xml.xsd
@@ -1,0 +1,146 @@
+<?xml version="1.0"?>
+<xs:schema targetNamespace="http://www.w3.org/XML/1998/namespace" xmlns:xs="http://www.w3.org/2001/XMLSchema" xml:lang="en">
+
+ <xs:annotation>
+  <xs:documentation>
+   See http://www.w3.org/XML/1998/namespace.html and
+   http://www.w3.org/TR/REC-xml for information about this namespace.
+
+    This schema document describes the XML namespace, in a form
+    suitable for import by other schema documents.  
+
+    Note that local names in this namespace are intended to be defined
+    only by the World Wide Web Consortium or its subgroups.  The
+    following names are currently defined in this namespace and should
+    not be used with conflicting semantics by any Working Group,
+    specification, or document instance:
+
+    base (as an attribute name): denotes an attribute whose value
+         provides a URI to be used as the base for interpreting any
+         relative URIs in the scope of the element on which it
+         appears; its value is inherited.  This name is reserved
+         by virtue of its definition in the XML Base specification.
+
+    id   (as an attribute name): denotes an attribute whose value
+         should be interpreted as if declared to be of type ID.
+         The xml:id specification is not yet a W3C Recommendation,
+         but this attribute is included here to facilitate experimentation
+         with the mechanisms it proposes.  Note that it is _not_ included
+         in the specialAttrs attribute group.
+
+    lang (as an attribute name): denotes an attribute whose value
+         is a language code for the natural language of the content of
+         any element; its value is inherited.  This name is reserved
+         by virtue of its definition in the XML specification.
+  
+    space (as an attribute name): denotes an attribute whose
+         value is a keyword indicating what whitespace processing
+         discipline is intended for the content of the element; its
+         value is inherited.  This name is reserved by virtue of its
+         definition in the XML specification.
+
+    Father (in any context at all): denotes Jon Bosak, the chair of 
+         the original XML Working Group.  This name is reserved by 
+         the following decision of the W3C XML Plenary and 
+         XML Coordination groups:
+
+             In appreciation for his vision, leadership and dedication
+             the W3C XML Plenary on this 10th day of February, 2000
+             reserves for Jon Bosak in perpetuity the XML name
+             xml:Father
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>This schema defines attributes and an attribute group
+        suitable for use by
+        schemas wishing to allow xml:base, xml:lang, xml:space or xml:id
+        attributes on elements they define.
+
+        To enable this, such a schema must import this schema
+        for the XML namespace, e.g. as follows:
+        &lt;schema . . .&gt;
+         . . .
+         &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                    schemaLocation="http://www.w3.org/2001/xml.xsd"/&gt;
+
+        Subsequently, qualified reference to any of the attributes
+        or the group defined below will have the desired effect, e.g.
+
+        &lt;type . . .&gt;
+         . . .
+         &lt;attributeGroup ref="xml:specialAttrs"/&gt;
+ 
+         will define a type which will schema-validate an instance
+         element with any of those attributes</xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>In keeping with the XML Schema WG's standard versioning
+   policy, this schema document will persist at
+   http://www.w3.org/2005/08/xml.xsd.
+   At the date of issue it can also be found at
+   http://www.w3.org/2001/xml.xsd.
+   The schema document at that URI may however change in the future,
+   in order to remain compatible with the latest version of XML Schema
+   itself, or with the XML namespace itself.  In other words, if the XML
+   Schema or XML namespaces change, the version of this document at
+   http://www.w3.org/2001/xml.xsd will change
+   accordingly; the version at
+   http://www.w3.org/2005/08/xml.xsd will not change.
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:attribute name="lang">
+  <xs:annotation>
+   <xs:documentation>Attempting to install the relevant ISO 2- and 3-letter
+         codes as the enumerated possible values is probably never
+         going to be a realistic possibility.  See
+         RFC 3066 at http://www.ietf.org/rfc/rfc3066.txt and the IANA registry
+         at http://www.iana.org/assignments/lang-tag-apps.htm for
+         further information.
+
+         The union allows for the 'un-declaration' of xml:lang with
+         the empty string.</xs:documentation>
+  </xs:annotation>
+  <xs:simpleType>
+   <xs:union memberTypes="xs:language">
+    <xs:simpleType>    
+     <xs:restriction base="xs:string">
+      <xs:enumeration value=""/>
+     </xs:restriction>
+    </xs:simpleType>
+   </xs:union>
+  </xs:simpleType>
+ </xs:attribute>
+
+ <xs:attribute name="space">
+  <xs:simpleType>
+   <xs:restriction base="xs:NCName">
+    <xs:enumeration value="default"/>
+    <xs:enumeration value="preserve"/>
+   </xs:restriction>
+  </xs:simpleType>
+ </xs:attribute>
+
+ <xs:attribute name="base" type="xs:anyURI">
+  <xs:annotation>
+   <xs:documentation>See http://www.w3.org/TR/xmlbase/ for
+                     information about this attribute.</xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+ 
+ <xs:attribute name="id" type="xs:ID">
+  <xs:annotation>
+   <xs:documentation>See http://www.w3.org/TR/xml-id/ for
+                     information about this attribute.</xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+
+ <xs:attributeGroup name="specialAttrs">
+  <xs:attribute ref="xml:base"/>
+  <xs:attribute ref="xml:lang"/>
+  <xs:attribute ref="xml:space"/>
+ </xs:attributeGroup>
+
+</xs:schema>

--- a/a3m/client/assets/premis/premis-v2-2.xsd
+++ b/a3m/client/assets/premis/premis-v2-2.xsd
@@ -1,0 +1,1387 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+via XML Spy. editor: Ray Denenberg, Library of Congress; rden@loc.gov   
+ 
+                             *********************************************************************************************
+                             *                                                                                                                    
+                             *                                                    PREMIS                                                   
+                             *                                     Preservation Metadata Schema                                
+                             *                                                                                                                  
+                             *                                                  VERSION 2.2                                            
+                             *                                                  May 15, 2012                       
+                            *                                                                                                                   
+                             *                            (supercedes version 2.1 of January 6, 2011)                       
+                             * 
+                             *           Modified:
+                             *               - July 2, 2012: removed extraneous whitespace within an element name. 
+                             *               - September 28, 2012: 
+                             *                    copyrightDocumentationIdentifier and licenseDocumentationIdentifier
+                             *                     changed to repeatable. They had been defined as non-repeatable in error. 
+                             *                                                                                                                  
+                             *********************************************************************************************
+
+
+
+**********************************************************************************************************************************
+Changes in version 2.2:
+
+1.	Complex element copyrightDocumentationIdentifier added to copyrightInformation (under rightsStatement). It has the following subelements:
+         copyrightDocumentationIdentifierType 
+         copyrightDocumentationIdentifierValue
+         copyrightDocumentationRole 
+
+                  In addition, copyrightApplicableDates (with a start and end date) is added to copyrightInformation.
+
+2. Complex element licenseDocumentationIdentifier is added to licenseInformation (under rightsStatement).   It is intended to replace existing element licenseIdentifier,  which is retained for backward compatibility.  It has subelements:
+        licenseDocumentationIdentifierType 
+    	licenseDocumentationIdentifierValue 
+        licenseDocumentationRole 
+The first two correspond to the existing subelements of licenseIndentifier:
+        licenseIdentifierType 
+    	licenseIdentifierValue 
+(The role element is added.)
+
+                  In addition, licenseApplicableDates (with a start and end date) is added to licenseInformation.
+
+3. Complex element statuteDocumentationIdentifier is added to statuteInformation (under rightsStatement). It has the following subelements:
+	  statuteDocumentationIdentifierType 
+      statuteDocumentationIdentifierValue 
+      statuteDocumentationRole 
+
+                  In addition, statuteApplicableDates (with a start and end date) is added to statuteInformation.
+
+4. Complex element otherRightsInformation is added to rightsStatement.  It has four subelements:
+     (1) otherRightsDocumentationIdentifier    - a complex element with subelements:
+		          otherRightsDocumentationIdentifierType 
+	  	          otherRightsDocumentationIdentifierValue
+		          otherRightsDocumentationRole 
+	   (2) otherRightsBasis  (simple)
+	   (3) otherRightsApplicableDates (with start and end dates) 
+	   (4) otherRightsNote (simple)
+
+5. Complex element termOfRestriction is added to rightsGranted (under rightsStatement). It has a start and end date. 
+
+6. countryCode definition added. Used by copyrightJurisdiction and statuteJurisdiction. Typed as xs:string, it does not introduce a substantive change, butt is introduced to reinforce the recommendation that a standard jurisdictional code be used.
+
+7. The pattern.... 
+	<xs:pattern value="OPEN"/>
+is added to the list of patterns supported in EDTF.
+
+*************************************************************************************************************************************   
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="info:lc/xmlns/premis-v2" targetNamespace="info:lc/xmlns/premis-v2" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<!--   
+ Import XLink-->
+	<xs:import namespace="http://www.w3.org/1999/xlink" schemaLocation="http://www.loc.gov/standards/xlink/xlink.xsd"/>
+	<!-- 	
+
+An instance is 
+(1) One or more of <object>, <event>, <agent>, <rights> all wrapped within a <premis> container; or
+(2) any one of  <object>, <event>, <agent>, <rights>  by itself. 
+
+Thus the root element is one of the following:  <premis>, <object>, <event>, <agent>, <rights> 
+
+********************************************************************************************
+*                                                                                                                 *
+*                            Root element declarations                                               *
+*                                                                                                                 *
+*********************************************************************************************
+
+-->
+	<xs:element name="premis" type="premisComplexType"/>
+	<xs:element name="object" type="objectComplexType"/>
+	<xs:element name="event" type="eventComplexType"/>
+	<xs:element name="agent" type="agentComplexType"/>
+	<xs:element name="rights" type="rightsComplexType"/>
+	<!-- 	
+
+
+*************************************************************************************************
+*                                                                                                                       *
+*                          definitions of complex types for the root elements                      *
+*                                                                                                                       *
+*************************************************************************************************
+
+************************************ premisComplexType 
+-->
+	<xs:complexType name="premisComplexType">
+		<xs:sequence>
+			<xs:element ref="object" maxOccurs="unbounded"/>
+			<xs:element ref="event" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="agent" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="rights" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="version" type="versionSimpleType" use="required"/>
+	</xs:complexType>
+	<!-- 	
+
+*************************************************************************************************
+*                                                                                                                       *
+*   objectComplexType  (and the three major <object>  category definitions)            *
+*                                                                                                                       *
+*************************************************************************************************
+
+-->
+	<xs:complexType name="objectComplexType" abstract="true"/>
+	<!--
+***************  
+The three "types":  'file', 'representation', and 'bitstream'. These are the values for the xsi:type attribute in an instance. 
+For an object of type file: <object xsi:type="file">  will mean that the complexType "file" will be validated. 
+For an object of type representation: <object xsi:type="representation">  will mean that the complexType "representation" will be validated. 
+For an object of type bitstream: <object xsi:type="bitstream">  will mean that the complexType "bitstream" will be validated. 
+******************
+
+******* file
+-->
+	<xs:complexType name="file">
+		<xs:complexContent>
+			<xs:extension base="objectComplexType">
+				<xs:sequence>
+					<xs:element ref="objectIdentifier" maxOccurs="unbounded"/>
+					<!-- Data dictionary lists objectCategory here, values:  'file', 'representation', or  'bitstream'. It is omitted and instead the mechanism described in the preceding comment is used to signify the category of the object. Using this mechanism allows for the specific definition, corresponding to the category, to be validated. In the older version there was a single defintion so specific vaidation based on category was not possible.  -->
+					<xs:element ref="preservationLevel" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element ref="significantProperties" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element ref="objectCharacteristics" maxOccurs="unbounded"/>
+					<xs:element ref="originalName" minOccurs="0"/>
+					<xs:element ref="storage" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element ref="environment" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element ref="signatureInformation" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element ref="relationship" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element ref="linkingEventIdentifier" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element ref="linkingIntellectualEntityIdentifier" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element ref="linkingRightsStatementIdentifier" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:sequence>
+				<xs:attribute name="xmlID" type="xs:ID"/>
+				<xs:attribute name="version" type="versionSimpleType"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--
+*********** representation
+  	-->
+	<xs:complexType name="representation">
+		<xs:complexContent>
+			<xs:extension base="objectComplexType">
+				<xs:sequence>
+					<xs:element ref="objectIdentifier" maxOccurs="unbounded"/>
+					<xs:element ref="preservationLevel" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element ref="significantProperties" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element ref="originalName" minOccurs="0"/>
+					<xs:element ref="environment" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element ref="relationship" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element ref="linkingEventIdentifier" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element ref="linkingIntellectualEntityIdentifier" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element ref="linkingRightsStatementIdentifier" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:sequence>
+				<xs:attribute name="xmlID" type="xs:ID"/>
+				<xs:attribute name="version" type="versionSimpleType"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--
+*********** bitstream
+  	-->
+	<xs:complexType name="bitstream">
+		<xs:complexContent>
+			<xs:extension base="objectComplexType">
+				<xs:sequence>
+					<xs:element ref="objectIdentifier" maxOccurs="unbounded"/>
+					<xs:element ref="significantProperties" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element ref="objectCharacteristics" maxOccurs="unbounded"/>
+					<xs:element ref="storage" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element ref="environment" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element ref="signatureInformation" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element ref="relationship" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element ref="linkingEventIdentifier" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element ref="linkingIntellectualEntityIdentifier" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element ref="linkingRightsStatementIdentifier" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:sequence>
+				<xs:attribute name="xmlID" type="xs:ID"/>
+				<xs:attribute name="version" type="versionSimpleType"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!-- 	
+
+************************************eventComplexType
+
+-->
+	<xs:complexType name="eventComplexType">
+		<xs:sequence>
+			<xs:element ref="eventIdentifier"/>
+			<xs:element ref="eventType"/>
+			<xs:element ref="eventDateTime"/>
+			<xs:element ref="eventDetail" minOccurs="0"/>
+			<xs:element ref="eventOutcomeInformation" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="linkingAgentIdentifier" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="linkingObjectIdentifier" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="xmlID" type="xs:ID"/>
+		<xs:attribute name="version" type="versionSimpleType"/>
+	</xs:complexType>
+	<!-- 	
+                      
+**************************  agentComplexType
+-->
+	<xs:complexType name="agentComplexType">
+		<xs:sequence>
+			<xs:element ref="agentIdentifier" maxOccurs="unbounded"/>
+			<xs:element ref="agentName" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="agentType" minOccurs="0"/>
+			<xs:element ref="agentNote" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="agentExtension" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="mdSec" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="linkingEventIdentifier" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="linkingRightsStatementIdentifier" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="xmlID" type="xs:ID"/>
+		<xs:attribute name="version" type="versionSimpleType"/>
+	</xs:complexType>
+	<!-- 	
+
+******************* rightsComplexType
+
+-->
+	<xs:complexType name="rightsComplexType">
+		<xs:choice maxOccurs="unbounded">
+			<xs:element ref="rightsStatement"/>
+			<xs:element ref="rightsExtension"/>
+			<xs:element ref="mdSec"/>
+		</xs:choice>
+		<xs:attribute name="xmlID" type="xs:ID"/>
+		<xs:attribute name="version" type="versionSimpleType"/>
+	</xs:complexType>
+	<!--
+
+********************************************************************************************
+********************************************************************************************
+*                                                                                                                 *
+*                     subsidiary  complexType definitions                                         *
+*                                                                                                                 *
+*********************************************************************************************
+*********************************************************************************************
+-->
+	<!--
+******* agentIdentifierComplexType
+-->
+	<xs:complexType name="agentIdentifierComplexType">
+		<xs:sequence>
+			<xs:element ref="agentIdentifierType"/>
+			<xs:element ref="agentIdentifierValue"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="xlink:simpleLink"/>
+	</xs:complexType>
+	<!--
+****************contentLocationComplexType
+-->
+	<xs:complexType name="contentLocationComplexType">
+		<xs:sequence>
+			<xs:element ref="contentLocationType"/>
+			<xs:element ref="contentLocationValue"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="xlink:simpleLink"/>
+	</xs:complexType>
+	<!--
+******** copyrightDocumentationIdentifierComplexType  ****** New in version 2.2 ******
+-->
+	<xs:complexType name="copyrightDocumentationIdentifierComplexType">
+		<xs:sequence>
+			<xs:element ref="copyrightDocumentationIdentifierType"/>
+			<xs:element ref="copyrightDocumentationIdentifierValue"/>
+			<xs:element ref="copyrightDocumentationRole" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--
+******** copyrightInformationComplexType
+-->
+	<xs:complexType name="copyrightInformationComplexType">
+		<xs:sequence>
+			<xs:element ref="copyrightStatus"/>
+			<xs:element ref="copyrightJurisdiction"/>
+			<xs:element ref="copyrightStatusDeterminationDate" minOccurs="0"/>
+			<xs:element ref="copyrightNote" minOccurs="0" maxOccurs="unbounded"/>
+			<!-- The following two elements are new in version 2.2 -->
+			<xs:element ref="copyrightDocumentationIdentifier" minOccurs="0" maxOccurs="unbounded"/> 
+			                                          <!-- *******************  maxOccurs="unbounded" added Sept. 28, 2012. it had been omitted in error -->
+			<xs:element ref="copyrightApplicableDates" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--
+****************creatingApplicationComplexType
+-->
+	<xs:complexType name="creatingApplicationComplexType">
+		<xs:choice>
+			<xs:sequence>
+				<xs:element ref="creatingApplicationName"/>
+				<xs:element ref="creatingApplicationVersion" minOccurs="0"/>
+				<xs:element ref="dateCreatedByApplication" minOccurs="0"/>
+				<xs:element ref="creatingApplicationExtension" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element ref="mdSec" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
+			<xs:sequence>
+				<xs:element ref="creatingApplicationVersion"/>
+				<xs:element ref="dateCreatedByApplication" minOccurs="0"/>
+				<xs:element ref="creatingApplicationExtension" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element ref="mdSec" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
+			<xs:sequence>
+				<xs:element ref="dateCreatedByApplication"/>
+				<xs:element ref="creatingApplicationExtension" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element ref="mdSec" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
+			<!-- -->
+			<xs:choice maxOccurs="unbounded">
+				<xs:element ref="creatingApplicationExtension"/>
+				<xs:element ref="mdSec"/>
+			</xs:choice>
+			<!-- -->
+		</xs:choice>
+		<!-- All of the  elements individually are optional, but at least one must occur. And those occuring must occur in the specified order. And some are non-repeatable. XML schema doesn't provide an easy way to define such a construct.  If  sequencing and non-repeatability didn't apply,  you could use CHOICE minOccurs="1" maxOccurs="unbounded". Or if the requirement that at least one must occur didn't apply you could use a single sequence all with minOccurs="0". But given these constraints the above structure is necessary. -->
+	</xs:complexType>
+	<!--  
+****************dependencyComplexType
+                                   See comment for "creatingApplicationComplexType"
+-->
+	<xs:complexType name="dependencyComplexType">
+		<xs:choice>
+			<xs:sequence>
+				<xs:element ref="dependencyName" maxOccurs="unbounded"/>
+				<xs:element ref="dependencyIdentifier" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
+			<xs:element ref="dependencyIdentifier" maxOccurs="unbounded"/>
+		</xs:choice>
+	</xs:complexType>
+	<!--  
+****************dependencyIdentifierComplexType
+-->
+	<xs:complexType name="dependencyIdentifierComplexType">
+		<xs:sequence>
+			<xs:element ref="dependencyIdentifierType"/>
+			<xs:element ref="dependencyIdentifierValue"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--  
+****************environmentComplexType
+                                   See comment for "creatingApplicationComplexType"
+-->
+	<xs:complexType name="environmentComplexType">
+		<xs:choice>
+			<!-- -->
+			<xs:sequence>
+				<xs:element ref="environmentCharacteristic"/>
+				<xs:element ref="environmentPurpose" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element ref="environmentNote" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element ref="dependency" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element ref="software" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element ref="hardware" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element ref="environmentExtension" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element ref="mdSec" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
+			<!-- -->
+			<xs:sequence>
+				<xs:element ref="environmentPurpose" maxOccurs="unbounded"/>
+				<xs:element ref="environmentNote" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element ref="dependency" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element ref="software" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element ref="hardware" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element ref="environmentExtension" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element ref="mdSec" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
+			<!-- -->
+			<xs:sequence>
+				<xs:element ref="environmentNote" maxOccurs="unbounded"/>
+				<xs:element ref="dependency" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element ref="software" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element ref="hardware" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element ref="environmentExtension" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element ref="mdSec" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
+			<!-- -->
+			<xs:sequence>
+				<xs:element ref="dependency" maxOccurs="unbounded"/>
+				<xs:element ref="software" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element ref="hardware" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element ref="environmentExtension" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element ref="mdSec" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
+			<!-- -->
+			<xs:sequence>
+				<xs:element ref="software" maxOccurs="unbounded"/>
+				<xs:element ref="hardware" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element ref="environmentExtension" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element ref="mdSec" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
+			<!-- -->
+			<xs:sequence>
+				<xs:element ref="hardware" maxOccurs="unbounded"/>
+				<xs:element ref="environmentExtension" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element ref="mdSec" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
+			<!-- -->
+			<xs:choice maxOccurs="unbounded">
+				<xs:element ref="environmentExtension"/>
+				<xs:element ref="mdSec"/>
+			</xs:choice>
+			<!-- -->
+		</xs:choice>
+	</xs:complexType>
+	<!--
+   ****eventIdentifierComplexType
+-->
+	<xs:complexType name="eventIdentifierComplexType">
+		<xs:sequence>
+			<xs:element ref="eventIdentifierType"/>
+			<xs:element ref="eventIdentifierValue"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="xlink:simpleLink"/>
+	</xs:complexType>
+	<!--
+   ****eventOutcomeDetailComplexType
+                                   See comment for "creatingApplicationComplexType"
+-->
+	<xs:complexType name="eventOutcomeDetailComplexType">
+		<xs:choice>
+			<xs:sequence>
+				<xs:element ref="eventOutcomeDetailNote"/>
+				<xs:element ref="eventOutcomeDetailExtension" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element ref="mdSec" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
+			<!---->
+			<xs:choice maxOccurs="unbounded">
+				<xs:element ref="eventOutcomeDetailExtension"/>
+				<xs:element ref="mdSec"/>
+			</xs:choice>
+			<!-- -->
+		</xs:choice>
+	</xs:complexType>
+	<!--
+   ****eventOutcomeInformationComplexType
+                                   See comment for "creatingApplicationComplexType"
+-->
+	<xs:complexType name="eventOutcomeInformationComplexType">
+		<xs:choice>
+			<xs:sequence>
+				<xs:element ref="eventOutcome"/>
+				<xs:element ref="eventOutcomeDetail" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
+			<xs:element ref="eventOutcomeDetail" maxOccurs="unbounded"/>
+		</xs:choice>
+	</xs:complexType>
+	<!--   
+*******fixityComplexType
+-->
+	<xs:complexType name="fixityComplexType">
+		<xs:sequence>
+			<xs:element ref="messageDigestAlgorithm"/>
+			<xs:element ref="messageDigest"/>
+			<xs:element ref="messageDigestOriginator" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--  
+*******formatComplexType
+-->
+	<xs:complexType name="formatComplexType">
+		<xs:sequence>
+			<xs:choice>
+				<!-- one or both of formatDesignation and/or formatRegistry required; followed optionally by formatNote -->
+				<xs:sequence>
+					<xs:element ref="formatDesignation"/>
+					<xs:element ref="formatRegistry" minOccurs="0"/>
+				</xs:sequence>
+				<xs:element ref="formatRegistry"/>
+			</xs:choice>
+			<xs:element ref="formatNote" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--  
+*******formatDesignationComplexType
+-->
+	<xs:complexType name="formatDesignationComplexType">
+		<xs:sequence>
+			<xs:element ref="formatName"/>
+			<xs:element ref="formatVersion" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--	  
+*******formatRegistryComplexType
+  -->
+	<xs:complexType name="formatRegistryComplexType">
+		<xs:sequence>
+			<xs:element ref="formatRegistryName"/>
+			<xs:element ref="formatRegistryKey"/>
+			<xs:element ref="formatRegistryRole" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="xlink:simpleLink"/>
+	</xs:complexType>
+	<!--  
+****************hardwareComplexType
+-->
+	<xs:complexType name="hardwareComplexType">
+		<xs:sequence>
+			<xs:element ref="hwName"/>
+			<xs:element ref="hwType"/>
+			<xs:element ref="hwOtherInformation" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--  
+****************inhibitorsComplexType
+-->
+	<xs:complexType name="inhibitorsComplexType">
+		<xs:sequence>
+			<xs:element ref="inhibitorType"/>
+			<xs:element ref="inhibitorTarget" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="inhibitorKey" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--
+******* licenseDocumentationIdentifierComplexType     ****** New in version 2.2 ******
+-->
+	<xs:complexType name="licenseDocumentationIdentifierComplexType">
+		<xs:sequence>
+			<xs:element ref="licenseDocumentationIdentifierType"/>
+			<xs:element ref="licenseDocumentationIdentifierValue"/>
+			<xs:element ref="licenseDocumentationRole" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--
+******* licenseIdentifierComplexType
+-->
+	<xs:complexType name="licenseIdentifierComplexType">
+		<xs:sequence>
+			<xs:element ref="licenseIdentifierType"/>
+			<xs:element ref="licenseIdentifierValue"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--
+******* licenseInformationComplexType
+                                   See comment for "creatingApplicationComplexType"
+-->
+	<xs:complexType name="licenseInformationComplexType">
+		<xs:choice>
+			<xs:sequence>
+				<!-- the following choice is introduced in version 2.2.  Previously it had been simply <licenseIdentifier> . In version 2.2 <licenseDocumentationIdentifier> is introduced as an alternative choice. <licenseIdentifier> is retained as an alternative for backward compatibility, however <licenseDocumentationIdentifier> is the preferred alternative. 
+
+licenseApplicableDates  is new in 2.2
+-->
+				<xs:choice>
+					<xs:element ref="licenseIdentifier"/>
+					<xs:element ref="licenseDocumentationIdentifier" maxOccurs="unbounded"/>
+                                         <!-- *******************  maxOccurs="unbounded" added Sept. 28, 2012. it had been omitted in error -->
+				</xs:choice>
+				<!-- -->
+				<xs:element ref="licenseTerms" minOccurs="0"/>
+				<xs:element ref="licenseNote" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element ref="licenseApplicableDates" minOccurs="0"/>
+			</xs:sequence>
+			<xs:sequence>
+				<xs:element ref="licenseTerms"/>
+				<xs:element ref="licenseNote" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element ref="licenseApplicableDates" minOccurs="0"/>
+			</xs:sequence>
+						<xs:sequence>
+			<xs:element ref="licenseNote" maxOccurs="unbounded"/>
+			<xs:element ref="licenseApplicableDates" minOccurs="0"/>
+			</xs:sequence>
+						<xs:element ref="licenseApplicableDates"/>
+		</xs:choice>
+	</xs:complexType>
+	<!--
+******* linkingAgentIdentifierComplexType
+-->
+	<xs:complexType name="linkingAgentIdentifierComplexType">
+		<xs:sequence>
+			<xs:element ref="linkingAgentIdentifierType"/>
+			<xs:element ref="linkingAgentIdentifierValue"/>
+			<xs:element ref="linkingAgentRole" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="LinkAgentXmlID" type="xs:IDREF"/>
+		<xs:attributeGroup ref="xlink:simpleLink"/>
+	</xs:complexType>
+	<!--  
+****************"linkingEventIdentifierComplexType
+-->
+	<xs:complexType name="linkingEventIdentifierComplexType">
+		<xs:sequence>
+			<xs:element ref="linkingEventIdentifierType"/>
+			<xs:element ref="linkingEventIdentifierValue"/>
+		</xs:sequence>
+		<xs:attribute name="LinkEventXmlID" type="xs:IDREF"/>
+		<xs:attributeGroup ref="xlink:simpleLink"/>
+	</xs:complexType>
+	<!--
+*******linkingObjectIdentifierComplexType	
+-->
+	<xs:complexType name="linkingObjectIdentifierComplexType">
+		<xs:sequence>
+			<xs:element ref="linkingObjectIdentifierType"/>
+			<xs:element ref="linkingObjectIdentifierValue"/>
+			<xs:element ref="linkingObjectRole" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="LinkObjectXmlID" type="xs:IDREF"/>
+		<xs:attributeGroup ref="xlink:simpleLink"/>
+	</xs:complexType>
+	<!--  
+****************linkingIntellectualEntityIdentifierComplexType
+-->
+	<xs:complexType name="linkingIntellectualEntityIdentifierComplexType">
+		<xs:sequence>
+			<xs:element ref="linkingIntellectualEntityIdentifierType"/>
+			<xs:element ref="linkingIntellectualEntityIdentifierValue"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="xlink:simpleLink"/>
+	</xs:complexType>
+	<!--  
+****************linkingRightsStatementIdentifierComplexType
+-->
+	<xs:complexType name="linkingRightsStatementIdentifierComplexType">
+		<xs:sequence>
+			<xs:element ref="linkingRightsStatementIdentifierType"/>
+			<xs:element ref="linkingRightsStatementIdentifierValue"/>
+		</xs:sequence>
+		<xs:attribute name="LinkPermissionStatementXmlID" type="xs:IDREF"/>
+		<xs:attributeGroup ref="xlink:simpleLink"/>
+	</xs:complexType>
+	<!--  
+****************objectCharacteristicsComplexType
+-->
+	<xs:complexType name="objectCharacteristicsComplexType">
+		<xs:sequence>
+			<xs:element ref="compositionLevel"/>
+			<xs:element ref="fixity" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="size" minOccurs="0"/>
+			<xs:element ref="format" maxOccurs="unbounded"/>
+			<xs:element ref="creatingApplication" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="inhibitors" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="objectCharacteristicsExtension" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="mdSec" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--  	
+*******objectIdentifierComplexType
+-->
+	<xs:complexType name="objectIdentifierComplexType">
+		<xs:sequence>
+			<xs:element ref="objectIdentifierType"/>
+			<xs:element ref="objectIdentifierValue"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="xlink:simpleLink"/>
+	</xs:complexType>
+	<!--  
+****************originalNameComplexType
+-->
+	<xs:complexType name="originalNameComplexType">
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:attributeGroup ref="xlink:simpleLink"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<!--  
+****************otherRightsDocumentationIdentifierComplexType     ****** New in version 2.2 ******
+-->
+	<xs:complexType name="otherRightsDocumentationIdentifierComplexType">
+		<xs:sequence>
+			<xs:element ref="otherRightsDocumentationIdentifierType"/>
+			<xs:element ref="otherRightsDocumentationIdentifierValue"/>
+			<xs:element ref="otherRightsDocumentationRole" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--  
+****************otherRightsInformationComplexType     ****** New in version 2.2 ******
+-->
+	<xs:complexType name="otherRightsInformationComplexType">
+		<xs:sequence>
+			<xs:element ref="otherRightsDocumentationIdentifier" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="otherRightsBasis"/>
+			<xs:element ref="otherRightsApplicableDates" minOccurs="0"/>
+			<xs:element ref="otherRightsNote" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--  
+****************preservationLevelComplexType
+-->
+	<xs:complexType name="preservationLevelComplexType">
+		<xs:sequence>
+			<xs:element ref="preservationLevelValue"/>
+			<xs:element ref="preservationLevelRole" minOccurs="0"/>
+			<xs:element ref="preservationLevelRationale" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="preservationLevelDateAssigned" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--  
+****************relatedEventIdentificationComplexType
+-->
+	<xs:complexType name="relatedEventIdentificationComplexType">
+		<xs:sequence>
+			<xs:element ref="relatedEventIdentifierType"/>
+			<xs:element ref="relatedEventIdentifierValue"/>
+			<xs:element ref="relatedEventSequence" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="RelEventXmlID" type="xs:IDREF"/>
+		<xs:attributeGroup ref="xlink:simpleLink"/>
+	</xs:complexType>
+	<!--  
+****************relatedObjectIdentificationComplexType
+-->
+	<xs:complexType name="relatedObjectIdentificationComplexType">
+		<xs:sequence>
+			<xs:element ref="relatedObjectIdentifierType"/>
+			<xs:element ref="relatedObjectIdentifierValue"/>
+			<xs:element ref="relatedObjectSequence" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="RelObjectXmlID" type="xs:IDREF"/>
+		<xs:attributeGroup ref="xlink:simpleLink"/>
+	</xs:complexType>
+	<!--  
+****************relationshipComplexType
+-->
+	<xs:complexType name="relationshipComplexType">
+		<xs:sequence>
+			<xs:element ref="relationshipType"/>
+			<xs:element ref="relationshipSubType"/>
+			<xs:element ref="relatedObjectIdentification" maxOccurs="unbounded"/>
+			<xs:element ref="relatedEventIdentification" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--
+******** rightsGrantedComplexType
+-->
+	<xs:complexType name="rightsGrantedComplexType">
+		<xs:sequence>
+			<xs:element ref="act"/>
+			<xs:element ref="restriction" minOccurs="0" maxOccurs="unbounded"/>
+			<!-- -->
+			<xs:element ref="termOfGrant" minOccurs="0"/>
+			<!-- Previously( in 2.1), termOfGrant (above) was mandatory. In 2.2 it is changed to  optional , and termOfRestriction (below) is added. Either one, or both, may occur.-->
+			<xs:element ref="termOfRestriction" minOccurs="0"/>
+						<!-- -->
+			<xs:element ref="rightsGrantedNote" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- 	
+******* rightsStatementComplexType
+-->
+	<xs:complexType name="rightsStatementComplexType">
+		<xs:sequence>
+			<xs:element ref="rightsStatementIdentifier"/>
+			<xs:element ref="rightsBasis"/>
+			<xs:element ref="copyrightInformation" minOccurs="0"/>
+			<xs:element ref="licenseInformation" minOccurs="0"/>
+			<xs:element ref="statuteInformation" minOccurs="0" maxOccurs="unbounded"/>
+			<!--The  following element (otherRightsInformation) is new in 2.2 -->
+			<xs:element ref="otherRightsInformation" minOccurs="0"/>
+			<xs:element ref="rightsGranted" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="linkingObjectIdentifier" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="linkingAgentIdentifier" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--
+*******rightsStatementIdentifierComplexType
+-->
+	<xs:complexType name="rightsStatementIdentifierComplexType">
+		<xs:sequence>
+			<xs:element ref="rightsStatementIdentifierType"/>
+			<xs:element ref="rightsStatementIdentifierValue"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="xlink:simpleLink"/>
+	</xs:complexType>
+	<!--  
+****************signatureComplexType
+-->
+	<xs:complexType name="signatureComplexType">
+		<xs:sequence>
+			<xs:element ref="signatureEncoding"/>
+			<xs:element ref="signer" minOccurs="0"/>
+			<xs:element ref="signatureMethod"/>
+			<xs:element ref="signatureValue"/>
+			<xs:element ref="signatureValidationRules"/>
+			<xs:element ref="signatureProperties" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="keyInformation" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="mdSec" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--  
+****************signatureInformationComplexType
+                                   See comment for "creatingApplicationComplexType"
+-->
+	<xs:complexType name="signatureInformationComplexType">
+		<xs:choice>
+			<xs:sequence>
+				<xs:element ref="signature"/>
+				<xs:element ref="signatureInformationExtension" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element ref="mdSec" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
+			<xs:choice maxOccurs="unbounded">
+				<xs:element ref="signatureInformationExtension"/>
+				<xs:element ref="mdSec"/>
+			</xs:choice>
+		</xs:choice>
+		<!-- -->
+	</xs:complexType>
+	<!-- 
+****************significantPropertiesComplexType
+                                   See comment for "creatingApplicationComplexType"
+ -->
+	<xs:complexType name="significantPropertiesComplexType">
+		<xs:choice>
+			<xs:sequence>
+				<xs:element ref="significantPropertiesType"/>
+				<xs:element ref="significantPropertiesValue" minOccurs="0"/>
+				<xs:element ref="significantPropertiesExtension" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element ref="mdSec" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
+			<xs:sequence>
+				<xs:element ref="significantPropertiesValue"/>
+				<xs:element ref="significantPropertiesExtension" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element ref="mdSec" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
+			<!---->
+			<xs:choice maxOccurs="unbounded">
+				<xs:element ref="significantPropertiesExtension"/>
+				<xs:element ref="mdSec"/>
+			</xs:choice>
+			<!-- -->
+		</xs:choice>
+	</xs:complexType>
+	<!--  
+****************softwareComplexType
+-->
+	<xs:complexType name="softwareComplexType">
+		<xs:sequence>
+			<xs:element ref="swName"/>
+			<xs:element ref="swVersion" minOccurs="0"/>
+			<xs:element ref="swType"/>
+			<xs:element ref="swOtherInformation" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="swDependency" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--  
+****************startAndEndDateComplexType     ****** New in version 2.2 ******
+-->
+	<xs:complexType name="startAndEndDateComplexType">
+		<xs:sequence>
+			<xs:element ref="startDate"/>
+			<xs:element ref="endDate" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--
+******* statuteDocumentationIdentifierComplexType     ****** New in version 2.2 ******
+-->
+	<xs:complexType name="statuteDocumentationIdentifierComplexType">
+		<xs:sequence>
+			<xs:element ref="statuteDocumentationIdentifierType"/>
+			<xs:element ref="statuteDocumentationIdentifierValue"/>
+			<xs:element ref="statuteDocumentationRole" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--
+******* statuteInformationComplexType
+-->
+	<xs:complexType name="statuteInformationComplexType">
+		<xs:sequence>
+			<xs:element ref="statuteJurisdiction"/>
+			<xs:element ref="statuteCitation"/>
+			<xs:element ref="statuteInformationDeterminationDate" minOccurs="0"/>
+			<xs:element ref="statuteNote" minOccurs="0" maxOccurs="unbounded"/>
+			<!-- the  following two elements are new in 2.2 -->
+			<xs:element ref="statuteDocumentationIdentifier" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="statuteApplicableDates" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--  
+****************storageComplexType
+                                   See comment for "creatingApplicationComplexType"
+-->
+	<xs:complexType name="storageComplexType">
+		<xs:choice>
+			<xs:sequence>
+				<xs:element ref="contentLocation"/>
+				<xs:element ref="storageMedium" minOccurs="0"/>
+			</xs:sequence>
+			<xs:element ref="storageMedium"/>
+		</xs:choice>
+	</xs:complexType>
+	<!-- 
+********************************************************************************************
+*                                                                                                                 *
+*                                   Element declarations                                               *
+*                                                                                                                 *
+*********************************************************************************************
+
+****** string type element declarations
+ 	-->
+	<xs:element name="act" type="xs:string"/>
+	<xs:element name="agentIdentifierType" type="xs:string"/>
+	<xs:element name="agentIdentifierValue" type="xs:string"/>
+	<xs:element name="agentName" type="xs:string"/>
+	<xs:element name="agentNote" type="xs:string"/>
+	<xs:element name="agentType" type="xs:string"/>
+	<xs:element name="contentLocationType" type="xs:string"/>
+	<xs:element name="contentLocationValue" type="xs:string"/>
+	<!-- Following three elements are new in version 2.2 -->
+	<xs:element name="copyrightDocumentationIdentifierType" type="xs:string"/>
+	<xs:element name="copyrightDocumentationRole" type="xs:string"/>
+	<xs:element name="copyrightDocumentationIdentifierValue" type="xs:string"/>
+	<!-- -->
+	<xs:element name="copyrightStatus" type="xs:string"/>
+	<!-- definition of copyrightJurisdiction changed in 2.2 -->
+	<xs:element name="copyrightJurisdiction" type="countryCode"/>
+	<xs:element name="copyrightNote" type="xs:string"/>
+	<xs:element name="creatingApplicationName" type="xs:string"/>
+	<xs:element name="creatingApplicationVersion" type="xs:string"/>
+	<xs:element name="dependencyIdentifierType" type="xs:string"/>
+	<xs:element name="dependencyIdentifierValue" type="xs:string"/>
+	<xs:element name="dependencyName" type="xs:string"/>
+	<xs:element name="environmentCharacteristic" type="xs:string"/>
+	<xs:element name="environmentNote" type="xs:string"/>
+	<xs:element name="environmentPurpose" type="xs:string"/>
+	<xs:element name="eventDetail" type="xs:string"/>
+	<xs:element name="eventIdentifierType" type="xs:string"/>
+	<xs:element name="eventIdentifierValue" type="xs:string"/>
+	<xs:element name="eventOutcome" type="xs:string"/>
+	<xs:element name="eventOutcomeDetailNote" type="xs:string"/>
+	<xs:element name="formatName" type="xs:string"/>
+	<xs:element name="formatNote" type="xs:string"/>
+	<xs:element name="formatRegistryName" type="xs:string"/>
+	<xs:element name="formatRegistryKey" type="xs:string"/>
+	<xs:element name="formatRegistryRole" type="xs:string"/>
+	<xs:element name="formatVersion" type="xs:string"/>
+	<xs:element name="hwOtherInformation" type="xs:string"/>
+	<xs:element name="hwName" type="xs:string"/>
+	<xs:element name="hwType" type="xs:string"/>
+	<xs:element name="inhibitorKey" type="xs:string"/>
+	<xs:element name="inhibitorTarget" type="xs:string"/>
+	<xs:element name="inhibitorType" type="xs:string"/>
+	<!-- Following three elements are new in version 2.2 -->
+	<xs:element name="licenseDocumentationIdentifierType" type="xs:string"/>
+	<xs:element name="licenseDocumentationRole" type="xs:string"/>
+	<xs:element name="licenseDocumentationIdentifierValue" type="xs:string"/>
+	<!-- -->
+	<xs:element name="licenseIdentifierType" type="xs:string"/>
+	<xs:element name="licenseIdentifierValue" type="xs:string"/>
+	<xs:element name="licenseNote" type="xs:string"/>
+	<xs:element name="licenseTerms" type="xs:string"/>
+	<xs:element name="linkingAgentIdentifierType" type="xs:string"/>
+	<xs:element name="linkingAgentIdentifierValue" type="xs:string"/>
+	<xs:element name="linkingAgentRole" type="xs:string"/>
+	<xs:element name="linkingEventIdentifierType" type="xs:string"/>
+	<xs:element name="linkingEventIdentifierValue" type="xs:string"/>
+	<xs:element name="linkingIntellectualEntityIdentifierType" type="xs:string"/>
+	<xs:element name="linkingIntellectualEntityIdentifierValue" type="xs:string"/>
+	<xs:element name="linkingObjectIdentifierType" type="xs:string"/>
+	<xs:element name="linkingObjectRole" type="xs:string"/>
+	<xs:element name="linkingObjectIdentifierValue" type="xs:string"/>
+	<xs:element name="linkingRightsStatementIdentifierType" type="xs:string"/>
+	<xs:element name="linkingRightsStatementIdentifierValue" type="xs:string"/>
+	<xs:element name="messageDigest" type="xs:string"/>
+	<xs:element name="messageDigestAlgorithm" type="xs:string"/>
+	<xs:element name="messageDigestOriginator" type="xs:string"/>
+	<xs:element name="objectIdentifierType" type="xs:string"/>
+	<xs:element name="objectIdentifierValue" type="xs:string"/>
+	<!-- Following five elements are new in version 2.2 -->
+	<xs:element name="otherRightsBasis" type="xs:string"/>
+	<xs:element name="otherRightsDocumentationRole" type="xs:string"/>
+	<xs:element name="otherRightsDocumentationIdentifierType" type="xs:string"/>
+	<xs:element name="otherRightsDocumentationIdentifierValue" type="xs:string"/>
+	<xs:element name="otherRightsNote" type="xs:string"/>
+	<!-- -->
+	<xs:element name="preservationLevelValue" type="xs:string"/>
+	<xs:element name="preservationLevelRole" type="xs:string"/>
+	<xs:element name="preservationLevelRationale" type="xs:string"/>
+	<xs:element name="relatedEventIdentifierType" type="xs:string"/>
+	<xs:element name="relatedEventIdentifierValue" type="xs:string"/>
+	<xs:element name="relatedObjectIdentifierType" type="xs:string"/>
+	<xs:element name="relatedObjectIdentifierValue" type="xs:string"/>
+	<xs:element name="relationshipType" type="xs:string"/>
+	<xs:element name="relationshipSubType" type="xs:string"/>
+	<xs:element name="restriction" type="xs:string"/>
+	<xs:element name="rightsBasis" type="xs:string"/>
+	<xs:element name="rightsGrantedNote" type="xs:string"/>
+	<xs:element name="rightsStatementIdentifierType" type="xs:string"/>
+	<xs:element name="rightsStatementIdentifierValue" type="xs:string"/>
+	<xs:element name="signatureEncoding" type="xs:string"/>
+	<xs:element name="signatureMethod" type="xs:string"/>
+	<xs:element name="signatureProperties" type="xs:string"/>
+	<xs:element name="signatureValue" type="xs:string"/>
+	<xs:element name="signatureValidationRules" type="xs:string"/>
+	<xs:element name="signer" type="xs:string"/>
+	<xs:element name="significantPropertiesType" type="xs:string"/>
+	<xs:element name="significantPropertiesValue" type="xs:string"/>
+	<xs:element name="storageMedium" type="xs:string"/>
+	<xs:element name="statuteCitation" type="xs:string"/>
+	<!-- Following three elements are new in version 2.2 -->
+	<xs:element name="statuteDocumentationIdentifierType" type="xs:string"/>
+	<xs:element name="statuteDocumentationIdentifierValue" type="xs:string"/>
+	<xs:element name="statuteDocumentationRole" type="xs:string"/>
+	<!-- definition of statuteJurisdiction changed in 2.2 -->
+	<xs:element name="statuteJurisdiction" type="countryCode"/>
+	<xs:element name="statuteNote" type="xs:string"/>
+	<xs:element name="swName" type="xs:string"/>
+	<xs:element name="swVersion" type="xs:string"/>
+	<xs:element name="swType" type="xs:string"/>
+	<xs:element name="swDependency" type="xs:string"/>
+	<xs:element name="swOtherInformation" type="xs:string"/>
+	<!-- 
+****** complex  type element declarations
+ 	-->
+	<xs:element name="agentIdentifier" type="agentIdentifierComplexType"/>
+	<xs:element name="contentLocation" type="contentLocationComplexType"/>
+	<!-- The following element (copyrightDocumentationIdentifier)  is new in version 2.2 -->
+	<xs:element name="copyrightDocumentationIdentifier" type="copyrightDocumentationIdentifierComplexType"/>
+	<xs:element name="copyrightInformation" type="copyrightInformationComplexType"/>
+	<xs:element name="creatingApplication" type="creatingApplicationComplexType"/>
+	<xs:element name="dependency" type="dependencyComplexType"/>
+	<xs:element name="dependencyIdentifier" type="dependencyIdentifierComplexType"/>
+	<xs:element name="environment" type="environmentComplexType"/>
+	<xs:element name="eventIdentifier" type="eventIdentifierComplexType"/>
+	<xs:element name="eventOutcomeDetail" type="eventOutcomeDetailComplexType"/>
+	<xs:element name="eventOutcomeInformation" type="eventOutcomeInformationComplexType"/>
+	<xs:element name="eventType" type="xs:string"/>
+	<xs:element name="fixity" type="fixityComplexType"/>
+	<xs:element name="format" type="formatComplexType"/>
+	<xs:element name="formatDesignation" type="formatDesignationComplexType"/>
+	<xs:element name="formatRegistry" type="formatRegistryComplexType"/>
+	<xs:element name="hardware" type="hardwareComplexType"/>
+	<xs:element name="inhibitors" type="inhibitorsComplexType"/>
+	<!-- the following element (licenseDocumentationIdentifier) is new in version 2.2 -->
+	<xs:element name="licenseDocumentationIdentifier" type="licenseDocumentationIdentifierComplexType"/>
+	<xs:element name="licenseIdentifier" type="licenseIdentifierComplexType"/>
+	<xs:element name="licenseInformation" type="licenseInformationComplexType"/>
+	<xs:element name="linkingAgentIdentifier" type="linkingAgentIdentifierComplexType"/>
+	<xs:element name="linkingEventIdentifier" type="linkingEventIdentifierComplexType"/>
+	<xs:element name="linkingIntellectualEntityIdentifier" type="linkingIntellectualEntityIdentifierComplexType"/>
+	<xs:element name="linkingObjectIdentifier" type="linkingObjectIdentifierComplexType"/>
+	<xs:element name="linkingRightsStatementIdentifier" type="linkingRightsStatementIdentifierComplexType"/>
+	<xs:element name="objectCharacteristics" type="objectCharacteristicsComplexType"/>
+	<xs:element name="objectIdentifier" type="objectIdentifierComplexType"/>
+	<xs:element name="originalName" type="originalNameComplexType"/>
+	<!-- Following two elements new in 2.2 -->
+	<xs:element name="otherRightsDocumentationIdentifier" type="otherRightsDocumentationIdentifierComplexType"/>
+	<xs:element name="otherRightsInformation" type="otherRightsInformationComplexType"/>
+	<!-- -->
+	<xs:element name="preservationLevel" type="preservationLevelComplexType"/>
+	<xs:element name="relatedEventIdentification" type="relatedEventIdentificationComplexType"/>
+	<xs:element name="relatedObjectIdentification" type="relatedObjectIdentificationComplexType"/>
+	<xs:element name="relationship" type="relationshipComplexType"/>
+	<xs:element name="rightsGranted" type="rightsGrantedComplexType"/>
+	<xs:element name="rightsStatement" type="rightsStatementComplexType"/>
+	<xs:element name="rightsStatementIdentifier" type="rightsStatementIdentifierComplexType"/>
+	<xs:element name="signature" type="signatureComplexType"/>
+	<xs:element name="signatureInformation" type="signatureInformationComplexType"/>
+	<xs:element name="significantProperties" type="significantPropertiesComplexType"/>
+	<!--  the following elelment (statuteDocumentationIdentifier) is new in 2.2 -->
+	<xs:element name="statuteDocumentationIdentifier" type="statuteDocumentationIdentifierComplexType"/>
+	<xs:element name="statuteInformation" type="statuteInformationComplexType"/>
+	<xs:element name="software" type="softwareComplexType"/>
+	<xs:element name="storage" type="storageComplexType"/>
+	<!-- 
+****** other xs  type  element declarations
+ 	-->
+	<xs:element name="compositionLevel" type="xs:nonNegativeInteger"/>
+	<xs:element name="relatedEventSequence" type="xs:nonNegativeInteger"/>
+	<xs:element name="relatedObjectSequence" type="xs:nonNegativeInteger"/>
+	<xs:element name="size" type="xs:long"/>
+	<!-- 
+****** date type  element declarations
+ 	-->
+	<xs:element name="dateCreatedByApplication" type="edtfSimpleType"/>
+	<xs:element name="endDate" type="edtfSimpleType"/>
+	<!-- the following element (copyRightApplicableDates) is  new in 2.2 -->
+	<xs:element name="copyrightApplicableDates" type="startAndEndDateComplexType"/>
+	<xs:element name="copyrightStatusDeterminationDate" type="edtfSimpleType"/>
+	<xs:element name="eventDateTime" type="edtfSimpleType"/>
+	<!-- the following element (licenseApplicableDates) is  new in 2.2 -->
+	<xs:element name="licenseApplicableDates" type="startAndEndDateComplexType"/>
+	<xs:element name="preservationLevelDateAssigned" type="edtfSimpleType"/>
+	<xs:element name="startDate" type="edtfSimpleType"/>
+	<!-- the following element (otherRightsApplicableDates) is  new in 2.2 -->
+	<xs:element name="otherRightsApplicableDates" type="startAndEndDateComplexType"/>
+	<!-- the following element (statuteApplicableDates) is  new in 2.2 -->
+	<xs:element name="statuteApplicableDates" type="startAndEndDateComplexType"/>
+	<xs:element name="statuteInformationDeterminationDate" type="edtfSimpleType"/>
+	<xs:element name="termOfGrant" type="startAndEndDateComplexType"/>
+	<xs:element name="termOfRestriction" type="startAndEndDateComplexType"/>
+	<!-- 
+****** extension  type  element declarations
+ 	-->
+	<xs:element name="agentExtension" type="extensionComplexType"/>
+	<xs:element name="creatingApplicationExtension" type="extensionComplexType"/>
+	<xs:element name="environmentExtension" type="extensionComplexType"/>
+	<xs:element name="eventOutcomeDetailExtension" type="extensionComplexType"/>
+	<xs:element name="keyInformation" type="extensionComplexType"/>
+	<xs:element name="objectCharacteristicsExtension" type="extensionComplexType"/>
+	<xs:element name="rightsExtension" type="extensionComplexType"/>
+	<xs:element name="signatureInformationExtension" type="extensionComplexType"/>
+	<xs:element name="significantPropertiesExtension" type="extensionComplexType"/>
+	<!--
+******************************************************************************************************
+************************************ Global Definitions  *******************************************
+******************************************************************************************************
+-->
+	<!--
+************** countryCode definition
+
+ countryCode added 2.2. Used by copyrightJurisdiction and statuteJurisdiction.  Although typed as xs:string, it is recommended that a standard jurisdictional code (such as ISO 3166-1 alpha-2 or alpha-3 country codes) be used, to ensure international uniqueness.  (Note: this does not introduce a substantive change. It is introduced to reinforce this recommendation.)
+-->
+	<xs:simpleType name="countryCode">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<!--
+************** version definition
+-->
+	<xs:simpleType name="versionSimpleType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="2.0"/>
+			<xs:enumeration value="2.1"/>
+			<xs:enumeration value="2.2"/>
+			<!-- 2.2 value added in version 2.2 -->
+		</xs:restriction>
+	</xs:simpleType>
+	<!--  
+****************	extensionComplexType	
+-->
+	<xs:complexType name="extensionComplexType">
+		<xs:sequence>
+			<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- 	
+****************************************************************************************************
+
+                               date/time Definition:  edtfSimpleType 
+                                       Extended Date/Time Format
+
+****************************************************************************************************
+
+edtfSimpleType  is the type used throughout the schema for "date"  and "dateTime" type elements: dateCreatedByApplication, copyrightStatusDeterminationDate, eventDateTime, preservationLevelDateAssigned, statuteInformationDeterminationDate, and others. 
+
+It is based on the edtf specification, and introduced into the PREMIS schema in version 2.0.  However this schema has not keet pace with the development of that spec, which has changed considerably since the release of version 2.0.
+
+edtfSimpleType  is the union of three simple types: xsDate, xs:dateTime -  and edtfRegularExpressions, as folloiws:
+ -->
+	<xs:simpleType name="edtfSimpleType">
+		<xs:union memberTypes="xs:date xs:dateTime edtfRegularExpressions"/>
+	</xs:simpleType>
+	<!-- 
+"xs:union" (above) means that any string conforming to any one of the types in the union will validate.  xs:date and xs:dateTime are built-in W3C schema types.  edtfRegularExpressions is a set of  regular expressions which are described below. So any string that conforms to one of the two built-in types or any of the  regular expressions will validate. 
+
+
+******** edftRegularExpressions
+-->
+	<xs:simpleType name="edtfRegularExpressions">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="\d{2}(\d{2}|\?\?|\d(\d|\?))(-(\d{2}|\?\?))?~?\??"/>
+			<xs:pattern value="\d{6}(\d{2}|\?\?)~?\??"/>
+			<xs:pattern value="\d{8}T\d{6}"/>
+			<xs:pattern value="((\d{4}(-\d{2})?)|UNKNOWN)/((\d{4}(-\d{2})?)|UNKNOWN|OPEN)"/>
+			<xs:pattern value="\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}((Z|(\+|-)\d{2}:\d{2}))?/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}((Z|(\+|-)\d{2}:\d{2}))?"/>
+			<!-- The following, "OPEN", introduced in version 2.2 -->
+			<xs:pattern value="OPEN"/>
+			<!-- 
+
+The first  pattern: 	
+<xs:pattern value="\d{2}(\d{2}|\?\?|\d(\d|\?))(-(\d{2}|\?\?))?~?\??"/>,  
+
+is for year (yyyy) or year-month (yyyy-mm).   The last or last two digits of year may be '?'  meaning "one year in that range but not sure which year", for example 19?? means some year from 1990 to 1999.  Similarly month may be '??' so that 2004-?? "means some month in 2004".  And the entire string may end with '?' or '~' for "uncertain" or "approximate".
+Hyphen must separate year and month.
+
+The second pattern:
+			<xs:pattern value="\d{6}(\d{2}|\?\?)~?\??"/>,
+
+is for  yearMonthDay - yyyymmdd,  where 'dd' may be '??'  so '200412??' means "some day during the month of 12/2004". 
+The whole  string may be followed by '?' or '~'  to mean "questionable" or "approximate".     hyphens are  not allowed for this pattern. 
+
+The Third patten:
+			<xs:pattern value="\d{8}T\d{6}"/>,
+
+is for  date and time with  T separator:'yyyymmddThhmmss'.  Hyphens in date and colons in time not allowed for this pattern.   
+
+The following pattern:
+			<xs:pattern value="((\d{4}(-\d{2})?)|UNKNOWN)/((\d{4}(-\d{2})?)|UNKNOWN|OPEN)"/>
+
+is for  a date range.  in years:  'yyyy/yyyy'; or year/month: yyyy-mm/yyyy-mm.    Beginning or end of range value may be 'UNKNOWN'. End of range value may be 'OPEN'.
+hyphens mandatory when month is present. 
+
+The  pattern  ...
+	<xs:pattern value="\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}((Z|(\+|-)\d{2}:\d{2}))?/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}((Z|(\+|-)\d{2}:\d{2}))?"></xs:pattern>
+
+....  supports time zones, e.g.
+
+2010-04-19T22:41:44Z/2010-04-19T22:48:50Z
+Or
+2010-04-19T22:41:44+02:00/2010-04-19T22:48:50+02:00.
+
+The pattern....
+	<xs:pattern value="OPEN"/>
+is introduced in version 2.2 to accomodate date elements that are structured into startDate and endDate.
+EDTF supports expression of start and end date in a single string (an interval). However, some date elements are still structured into a start and end date, and "OPEN" needs to be supported as an end date. Prior to this version, "OPEN" was valid only within an interval. This allow it to be used as a standalone date. It is intended to be used as such only as the end date of a structured date, but this cannot be enforced.
+
+-->
+		</xs:restriction>
+	</xs:simpleType>
+	<!--
+
+****************************************************************************************************************************************
+****************************************************************************************************************************************
+Following is the definition of the <mdSec> element  (first introcuced in version 2.1).  <mdSec> is offered as an alternative to an extension  element, wherever an extension element occurs. 
+
+                             *********************************************************************************************
+                             *********************************************************************************************
+                             *                                                                                                                  *
+                             *                                          <mdSec> element                                             *
+                             *                                                                                                                  *
+                             *                                                                                                                  *
+                             *********************************************************************************************
+                            *********************************************************************************************                        
+-->
+	<xs:element name="mdSec" type="mdSecDefinition"/>
+	<!--
+
+************ mdSecDefinition
+
+<mdSec> is a generalization of several METS metadata type elements: <dmdSec>, <amdSec>, etc. all of METS 
+type "mdSecType".  PREMIS generalized these into a single element because it does not distinguish between 
+these different types of metadata (e.g. administrative vs. descriptive). 
+ 
+<mdSec>  includes one or both of <mdRef> and <mdWrap>, a reference to external metadata and a wrapper of 
+internal metadata, respectively. <mdRef> is an empty element with a link (an attribute) to external metadata.  
+<mdWrap> includes the metadata, either as <xmlData> or <binData>.
+
+-->
+	<xs:complexType name="mdSecDefinition">
+		<xs:all>
+			<xs:element ref="mdRef" minOccurs="0"/>
+			<xs:element ref="mdWrap" minOccurs="0"/>
+		</xs:all>
+		<xs:attribute name="ID" type="xs:ID" use="required"/>
+		<xs:attribute name="GROUPID" type="xs:string"/>
+		<xs:attribute name="ADMID" type="xs:IDREFS"/>
+		<xs:attribute name="CREATED" type="edtfSimpleType"/>
+		<xs:attribute name="STATUS" type="xs:string"/>
+	</xs:complexType>
+	<!--
+
+************ mdRefDefinition
+<mdRef> (metadata reference)  is an empty element providing pointers (via xlink and XPTR attributes) to metadata outside the PREMIS document.  
+-->
+	<xs:complexType name="mdRefDefinition">
+		<xs:attribute name="ID" type="xs:ID"/>
+		<xs:attribute name="LOCTYPE" type="LOCTYPEDefinition" use="required"/>
+		<xs:attribute name="OTHERLOCTYPE" type="xs:string"/>
+		<xs:attributeGroup ref="xlink:simpleLink"/>
+		<xs:attributeGroup ref="metadataAttributeGroup"/>
+		<xs:attributeGroup ref="filecoreAttributeGroup"/>
+		<xs:attribute name="LABEL" type="xs:string"/>
+		<xs:attribute name="XPTR" type="xs:string"/>
+		<!-- -->
+		<!-- 
+         <LOCTYPE> must be supplied, and its value may be "other"
+         in which case <OTHERLOCTYPE> should be supplied.
+-->
+	</xs:complexType>
+	<!-- 
+********* mdWrapDefinition
+-->
+	<xs:complexType name="mdWrapDefinition">
+		<xs:choice>
+			<xs:element ref="binData" minOccurs="0"/>
+			<xs:element ref="xmlData" minOccurs="0"/>
+		</xs:choice>
+		<xs:attribute name="ID" type="xs:ID"/>
+		<xs:attributeGroup ref="metadataAttributeGroup"/>
+		<xs:attributeGroup ref="filecoreAttributeGroup"/>
+		<xs:attribute name="LABEL" type="xs:string"/>
+		<!--
+						<mdWrap> (metadata wrapper) wraps metadata in one of the following forms: 
+1) XML-encoded (belonging to any namespace) wrapped in an <xmlData>  element. . 
+2) Arbitrary Base64 encoded  wrapped in a <binData>  element. 
+-->
+	</xs:complexType>
+	<!-- 
+xmlDataDefinition 
+-->
+	<xs:complexType name="xmlDataDefinition">
+		<xs:sequence>
+			<xs:any namespace="##any" processContents="lax" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- 
+MDTYPEDefinition
+-->
+	<xs:simpleType name="MDTYPEDefinition">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="MIX"/>
+			<xs:enumeration value="LC-VIDEO"/>
+			<xs:enumeration value="LC-AUDIO"/>
+			<xs:enumeration value="TEXTMD"/>
+			<xs:enumeration value="METSRIGHTS"/>
+			<xs:enumeration value="CDLCopyright"/>
+			<xs:enumeration value="XMLSignature"/>
+			<xs:enumeration value="OTHER"/>
+		</xs:restriction>
+		<!-- this list of values differs from the list in METS -->
+	</xs:simpleType>
+	<!--
+LOCTYPEDefinition
+-->
+	<xs:simpleType name="LOCTYPEDefinition">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="ARK"/>
+			<xs:enumeration value="URN"/>
+			<xs:enumeration value="URL"/>
+			<xs:enumeration value="PURL"/>
+			<xs:enumeration value="HANDLE"/>
+			<xs:enumeration value="DOI"/>
+			<xs:enumeration value="OTHER"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!--
+CHECKSUMTYPEDefinition
+-->
+	<xs:simpleType name="CHECKSUMTYPEDefinition">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Adler-32"/>
+			<xs:enumeration value="CRC32"/>
+			<xs:enumeration value="HAVAL"/>
+			<xs:enumeration value="MD5"/>
+			<xs:enumeration value="MNP"/>
+			<xs:enumeration value="SHA-1"/>
+			<xs:enumeration value="SHA-256"/>
+			<xs:enumeration value="SHA-384"/>
+			<xs:enumeration value="SHA-512"/>
+			<xs:enumeration value="TIGER"/>
+			<xs:enumeration value="WHIRLPOOL"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!--
+*************** attribute group definitions
+-->
+	<!--
+
+**** metadataAttributeGroup
+-->
+	<xs:attributeGroup name="metadataAttributeGroup">
+		<xs:attribute name="MDTYPE" type="MDTYPEDefinition" use="required"/>
+		<xs:attribute name="OTHERMDTYPE" type="xs:string"/>
+		<xs:attribute name="MDTYPEVERSION" type="xs:string"/>
+	</xs:attributeGroup>
+	<!--
+
+**** filecoreAttributeGroup
+-->
+	<xs:attributeGroup name="filecoreAttributeGroup">
+		<xs:attribute name="MIMETYPE" type="xs:string"/>
+		<xs:attribute name="SIZE" type="xs:long"/>
+		<xs:attribute name="CREATED" type="edtfSimpleType"/>
+		<xs:attribute name="CHECKSUM" type="xs:string"/>
+		<xs:attribute name="CHECKSUMTYPE" type="CHECKSUMTYPEDefinition"/>
+	</xs:attributeGroup>
+	<!-- 
+Element Declarations 
+-->
+	<xs:element name="binData" type="xs:base64Binary"/>
+	<xs:element name="mdRef" type="mdRefDefinition"/>
+	<xs:element name="mdWrap" type="mdWrapDefinition"/>
+	<xs:element name="xmlData" type="xmlDataDefinition"/>
+	<!-- -->
+</xs:schema>

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -75,8 +75,6 @@ filelock==3.12.2
     #   virtualenv
 flake8==4.0.1
     # via a3m (setup.py)
-future==0.18.3
-    # via metsrw
 gitdb==4.0.9
     # via gitpython
 gitpython==3.1.32
@@ -132,7 +130,7 @@ mccabe==0.6.1
     # via
     #   flake8
     #   pylint
-metsrw==0.3.21
+metsrw==0.4.0
     # via a3m (setup.py)
 multidict==6.0.2
     # via yarl
@@ -235,7 +233,6 @@ semantic-version==2.6.0
     # via releases
 six==1.16.0
     # via
-    #   metsrw
     #   python-dateutil
     #   vcrpy
 smmap==5.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,8 +34,6 @@ commonmark==0.9.1
     # via rich
 django==3.2.20
     # via a3m (setup.py)
-future==0.18.3
-    # via metsrw
 googleapis-common-protos==1.60.0
     # via
     #   a3m (setup.py)
@@ -62,7 +60,7 @@ lxml==4.9.3
     #   a3m (setup.py)
     #   ammcpc
     #   metsrw
-metsrw==0.3.21
+metsrw==0.4.0
     # via a3m (setup.py)
 prometheus-client==0.14.1
     # via a3m (setup.py)
@@ -88,9 +86,7 @@ rich==10.16.2
 s3transfer==0.5.2
     # via boto3
 six==1.16.0
-    # via
-    #   metsrw
-    #   python-dateutil
+    # via python-dateutil
 sqlparse==0.4.4
     # via django
 tenacity==8.0.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ python_requires = ~=3.9
 install_requires =
     # Used by client modules
     ammcpc~=0.1
-    metsrw~=0.3
+    metsrw~=0.4
     bagit~=1.7
     clamd~=1.0
     lxml~=4.7

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+import pathlib
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def set_xml_catalog_files(monkeypatch):
+    """Use local XML schemas for validation."""
+    monkeypatch.setenv(
+        "XML_CATALOG_FILES",
+        str(
+            pathlib.Path(__file__).parent.parent
+            / "a3m/client/assets/catalog/catalog.xml"
+        ),
+    )


### PR DESCRIPTION
Based on:
- https://github.com/artefactual/archivematica/pull/1827
- https://github.com/artefactual/archivematica/pull/1830

Fixes some issues experienced while validating XML documents within our tests:

    Failed to parse the XML resource 'http://www.loc.gov/standards/xlink/xlink.xsd'., line 4.