### PR TITLE
Install pyright

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -2,4 +2,4 @@
 extension-pkg-whitelist=lxml
 
 [MESSAGES CONTROL]
-disable=C, F, I, R, W, E1101, E1133, E0611
+disable=C, F, I, R, W, E1101, E1133

--- a/a3m/client/clientScripts/a3m_download_transfer.py
+++ b/a3m/client/clientScripts/a3m_download_transfer.py
@@ -97,7 +97,9 @@ def _process_http_url(job, url, transfer_path, transfer_id):
     with _create_tmpdir(transfer_id, purpose="download") as tmp_dir:
         download = tmp_dir / Path(url.path).name
         try:
-            with requests.get(url.geturl(), allow_redirects=True, stream=True) as resp:
+            with requests.get(
+                url.geturl(), allow_redirects=True, stream=True, timeout=100
+            ) as resp:
                 resp.raise_for_status()
                 with download.open("wb") as f:
                     for chunk in resp.iter_content(chunk_size=8192):

--- a/a3m/client/clientScripts/characterize_file.py
+++ b/a3m/client/clientScripts/characterize_file.py
@@ -99,13 +99,13 @@ def main(job, file_path, file_uuid, sip_uuid):
                 failed = True
                 job.write_error(
                     'XML output for command "{}" ({}) was not valid XML; not saving to database'.format(
-                        rule.command.description, rule.command.uuid
+                        rule.command.description, rule.command.id
                     )
                 )
         else:
             job.write_error(
                 'Tool output for command "{}" ({}) is not XML; not saving to database'.format(
-                    rule.command.description, rule.command.uuid
+                    rule.command.description, rule.command.id
                 )
             )
 

--- a/a3m/client/clientScripts/check_for_submission_documentation.py
+++ b/a3m/client/clientScripts/check_for_submission_documentation.py
@@ -31,4 +31,4 @@ def call(jobs):
                 f = open(fileName, "a")
                 f.write("No submission documentation added")
                 f.close()
-                os.chmod(fileName, 0o660)
+                os.chmod(fileName, 0o600)

--- a/a3m/client/mcp.py
+++ b/a3m/client/mcp.py
@@ -76,11 +76,13 @@ replacement_dict = {
 def handle_batch_task(task_name, batch_payload):
     tasks = batch_payload["tasks"]
 
+    mod = ""
     utc_date = getUTCDate()
     jobs = []
     for task_uuid in tasks:
         task_data = tasks[task_uuid]
         arguments = task_data["arguments"]
+        mod = task_data["execute"]
 
         replacements = list(replacement_dict.items()) + list(
             {
@@ -110,7 +112,7 @@ def handle_batch_task(task_name, batch_payload):
 
     retryOnFailure("Set task start times", set_start_times)
 
-    module = importlib.import_module("a3m.client.clientScripts." + task_data["execute"])
+    module = importlib.import_module(f"a3m.client.clientScripts.{mod}")
     module.call(jobs)
 
     return jobs

--- a/a3m/fpr/registry.py
+++ b/a3m/fpr/registry.py
@@ -49,6 +49,7 @@ from typing import TypeVar
 from django.apps import apps
 
 
+# Avoid issues with circular imports.
 if TYPE_CHECKING:
     from a3m.main.models import File
 else:
@@ -496,8 +497,8 @@ class Registry:
     def __init__(self, backend: Backend | None = None):
         self.backend = backend or default_backend
 
-    def _file_model(self):
-        return apps.get_model("main.File")
+    def _file_model(self) -> File:
+        return apps.get_model("main.File")  # type: ignore
 
     def get_format_version_by_id(self, id: uuid.UUID) -> FormatVersion | None:
         """Returns a format version given its identifier.
@@ -535,13 +536,14 @@ class Registry:
 
         It omits rules not in service.
 
-        TODO: refactor as method of the File model.
+        TODO: refactor as method of the File mode, should also typing and circular import issues.
         """
         result: list[Rule] = []
         if isinstance(purpose, str):
             purpose = RulePurpose(purpose)
-        if isinstance(file, self._file_model()):
-            file_obj = file
+        file_obj: File
+        if str(type(file).__name__) == File:
+            file_obj = file  # type: ignore
         elif isinstance(file, uuid.UUID):
             file_obj = self._file_model().objects.get(pk=str(file))
         elif isinstance(file, str):

--- a/a3m/main/models.py
+++ b/a3m/main/models.py
@@ -22,6 +22,7 @@ import re
 import uuid
 from collections.abc import Iterator
 from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 from django.db import models
 from django.db.models.signals import post_delete
@@ -30,6 +31,11 @@ from django.utils.translation import gettext_lazy as _
 
 from a3m.fpr.registry import FormatVersion
 from a3m.fpr.registry import FPR
+
+
+if TYPE_CHECKING:
+    # This doesn't really exists on django so it always need to be imported this way
+    from django.db.models.manager import RelatedManager
 
 
 logger = logging.getLogger(__name__)
@@ -314,6 +320,9 @@ class Transfer(models.Model):
 
     objects = UnitHiddenManager()
 
+    if TYPE_CHECKING:
+        file_set = RelatedManager["File"]()
+
     class Meta:
         db_table = "Transfers"
 
@@ -395,6 +404,11 @@ class File(models.Model):
     # values can be constructed using the DashboardSettings rows with scope
     # 'handle'.
     identifiers = models.ManyToManyField("Identifier")
+
+    if TYPE_CHECKING:
+        fileformatversion_set = RelatedManager["FileFormatVersion"]()
+        event_set = RelatedManager["Event"]()
+        fpcommandoutput_set = RelatedManager["FPCommandOutput"]()
 
     class Meta:
         db_table = "Files"

--- a/a3m/settings/common.py
+++ b/a3m/settings/common.py
@@ -7,9 +7,14 @@ from io import StringIO
 from pathlib import Path
 from typing import Any
 
+import django_stubs_ext
 from appdirs import user_data_dir
 
 from a3m.appconfig import Config
+
+
+django_stubs_ext.monkeypatch()
+
 
 CONFIG_MAPPING = {
     "debug": {"section": "a3m", "option": "debug", "type": "boolean"},

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -12,8 +12,20 @@ The requirements are listed in ``/setup.cfg`` under (``install_requires``). The
 constraints are relaxed with the purpose of allowing a3m to be used as a
 library.
 
-We use `pip-tools` which reflects the requirements in ``requirements.txt`` and
-``requirements-dev.txt`` for our Docker image.
+We use `pip-tools` which pins the requirements in ``requirements.txt`` and
+``requirements-dev.txt`` for our Docker image and tox. Some examples:
+
+* Update dependencies with::
+ 
+   pip-compile --output-file=requirements.txt setup.py
+
+* Update all dependencies with::
+
+   pip-compile --upgrade --output-file=requirements.txt setup.py
+
+* Update all development dependencies with::
+
+   pip-compile --extra=dev --upgrade --output-file=requirements-dev.txt setup.py
 
 Python version
 ^^^^^^^^^^^^^^

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,14 @@ ignore = [
 exclude = [
   "a3m/api/**/*",
 ]
+
+[tool.pyright]
+include = [
+  "a3m",
+  "tests",
+]
+exclude = [
+  "a3m/api/*/**",
+  "a3m/main/migrations/*/**",
+]
+typeCheckingMode = "basic"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --extra=dev --output-file=requirements-dev.txt setup.py
 #
-alabaster==0.7.12
+alabaster==0.7.13
     # via sphinx
 ammcpc==0.1.3
     # via a3m (setup.py)
@@ -12,66 +12,72 @@ appdirs==1.4.4
     # via a3m (setup.py)
 asgiref==3.7.2
     # via django
-astroid==2.11.2
+astroid==3.0.1
     # via pylint
 attrs==23.1.0
     # via
     #   jsonschema
     #   referencing
-babel==2.9.1
+babel==2.13.0
     # via sphinx
 bagit==1.8.1
     # via a3m (setup.py)
-bandit==1.7.4
+bandit==1.7.5
     # via a3m (setup.py)
-black==22.3.0
+black==23.10.1
     # via a3m (setup.py)
-boto3==1.28.62
+boto3==1.28.69
     # via a3m (setup.py)
-botocore==1.31.62
+botocore==1.31.69
     # via
     #   boto3
     #   s3transfer
-build==0.10.0
+build==1.0.3
     # via pip-tools
 cachetools==5.3.1
     # via tox
 certifi==2023.7.22
     # via requests
-cfgv==3.3.1
+cfgv==3.4.0
     # via pre-commit
 chardet==5.2.0
     # via tox
-charset-normalizer==2.0.12
+charset-normalizer==3.3.1
     # via requests
-click==8.1.2
+click==8.1.7
     # via
     #   a3m (setup.py)
     #   black
     #   pip-tools
 colorama==0.4.6
     # via tox
-coverage[toml]==7.2.7
+coverage[toml]==7.3.2
     # via
     #   a3m (setup.py)
     #   pytest-cov
-dill==0.3.4
+dill==0.3.7
     # via pylint
 distlib==0.3.7
     # via virtualenv
 django==4.2.6
+    # via
+    #   a3m (setup.py)
+    #   django-stubs-ext
+django-stubs-ext==4.2.5
     # via a3m (setup.py)
-docutils==0.17.1
+django-types==0.19.1
+    # via a3m (setup.py)
+docutils==0.20.1
     # via sphinx
-filelock==3.12.2
+filelock==3.12.4
     # via
     #   tox
     #   virtualenv
-flake8==4.0.1
+flake8==6.1.0
     # via a3m (setup.py)
-gitdb==4.0.9
+gitdb==4.0.11
     # via gitpython
-gitpython==3.1.37
+gitpython==3.1.40
     # via bandit
 googleapis-common-protos==1.61.0
     # via
@@ -87,21 +93,21 @@ grpcio-reflection==1.59.0
     # via a3m (setup.py)
 grpcio-status==1.59.0
     # via a3m (setup.py)
-grpcio-tools==1.56.2
+grpcio-tools==1.59.0
     # via a3m (setup.py)
-identify==2.4.12
+identify==2.5.30
     # via pre-commit
-idna==3.3
+idna==3.4
     # via requests
-imagesize==1.3.0
+imagesize==1.4.1
     # via sphinx
-iniconfig==1.1.1
+iniconfig==2.0.0
     # via pytest
-isort==5.10.1
+isort==5.12.0
     # via pylint
-jinja2==3.1.1
+jinja2==3.1.2
     # via sphinx
-jmespath==1.0.0
+jmespath==1.0.1
     # via
     #   boto3
     #   botocore
@@ -109,8 +115,6 @@ jsonschema==4.19.1
     # via a3m (setup.py)
 jsonschema-specifications==2023.7.1
     # via jsonschema
-lazy-object-proxy==1.7.1
-    # via astroid
 lxml==4.9.3
     # via
     #   a3m (setup.py)
@@ -118,9 +122,9 @@ lxml==4.9.3
     #   metsrw
 markdown-it-py==3.0.0
     # via rich
-markupsafe==2.1.1
+markupsafe==2.1.3
     # via jinja2
-mccabe==0.6.1
+mccabe==0.7.0
     # via
     #   flake8
     #   pylint
@@ -128,64 +132,65 @@ mdurl==0.1.2
     # via markdown-it-py
 metsrw==0.4.0
     # via a3m (setup.py)
-mypy==0.942
+mypy==1.6.1
     # via a3m (setup.py)
-mypy-extensions==0.4.3
+mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
-nodeenv==1.6.0
+nodeenv==1.8.0
     # via pre-commit
-packaging==23.1
+packaging==23.2
     # via
+    #   black
     #   build
     #   pyproject-api
     #   pytest
     #   sphinx
     #   tox
-pathspec==0.9.0
+pathspec==0.11.2
     # via black
-pbr==5.8.1
+pbr==5.11.1
     # via stevedore
 pip-tools==7.3.0
     # via a3m (setup.py)
-platformdirs==3.10.0
+platformdirs==3.11.0
     # via
     #   black
     #   pylint
     #   tox
     #   virtualenv
-pluggy==1.2.0
+pluggy==1.3.0
     # via
     #   pytest
     #   tox
-pre-commit==2.18.1
+pre-commit==3.5.0
     # via a3m (setup.py)
 prometheus-client==0.17.1
     # via a3m (setup.py)
-protobuf==4.24.0
+protobuf==4.24.4
     # via
     #   googleapis-common-protos
     #   grpcio-reflection
     #   grpcio-status
     #   grpcio-tools
-pycodestyle==2.8.0
+pycodestyle==2.11.1
     # via flake8
-pyflakes==2.4.0
+pyflakes==3.1.0
     # via flake8
 pygfried==0.6.0
     # via a3m (setup.py)
-pygments==2.15.0
+pygments==2.16.1
     # via
     #   rich
     #   sphinx
-pylint==2.13.5
+pylint==3.0.2
     # via a3m (setup.py)
-pyproject-api==1.5.3
+pyproject-api==1.6.1
     # via tox
 pyproject-hooks==1.0.0
     # via build
-pytest==7.4.0
+pytest==7.4.2
     # via
     #   a3m (setup.py)
     #   pytest-cov
@@ -196,15 +201,13 @@ pytest-cov==4.1.0
     # via a3m (setup.py)
 pytest-django==4.5.2
     # via a3m (setup.py)
-pytest-env==0.8.2
+pytest-env==1.1.0
     # via a3m (setup.py)
-pytest-mock==3.7.0
+pytest-mock==3.12.0
     # via a3m (setup.py)
 python-dateutil==2.8.2
     # via botocore
-pytz==2022.1
-    # via babel
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   bandit
     #   pre-commit
@@ -217,7 +220,9 @@ requests==2.31.0
     #   a3m (setup.py)
     #   sphinx
 rich==13.6.0
-    # via a3m (setup.py)
+    # via
+    #   a3m (setup.py)
+    #   bandit
 rpds-py==0.10.6
     # via
     #   jsonschema
@@ -226,58 +231,71 @@ s3transfer==0.7.0
     # via boto3
 six==1.16.0
     # via python-dateutil
-smmap==5.0.0
+smmap==5.0.1
     # via gitdb
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==4.5.0
-    # via a3m (setup.py)
-sphinxcontrib-applehelp==1.0.2
+sphinx==7.2.6
+    # via
+    #   a3m (setup.py)
+    #   sphinxcontrib-applehelp
+    #   sphinxcontrib-devhelp
+    #   sphinxcontrib-htmlhelp
+    #   sphinxcontrib-qthelp
+    #   sphinxcontrib-serializinghtml
+sphinxcontrib-applehelp==1.0.7
     # via sphinx
-sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-devhelp==1.0.5
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.0
+sphinxcontrib-htmlhelp==2.0.4
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-mermaid==0.7.1
+sphinxcontrib-mermaid==0.9.2
     # via a3m (setup.py)
-sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-qthelp==1.0.6
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.5
+sphinxcontrib-serializinghtml==1.1.9
     # via sphinx
 sqlparse==0.4.4
     # via django
-stevedore==3.5.0
+stevedore==5.1.0
     # via bandit
 tenacity==8.2.3
     # via a3m (setup.py)
 toml==0.10.2
+    # via vulture
+tomlkit==0.12.1
+    # via pylint
+tox==4.11.3
+    # via a3m (setup.py)
+types-beautifulsoup4==4.12.0.6
+    # via types-lxml
+types-html5lib==1.1.11.15
+    # via types-beautifulsoup4
+types-lxml==2023.10.21
+    # via a3m (setup.py)
+types-psycopg2==2.9.21.14
+    # via django-types
+typing-extensions==4.8.0
     # via
-    #   pre-commit
-    #   vulture
-tomli==2.0.1
-    # via mypy
-tox==4.6.4
+    #   django-stubs-ext
+    #   mypy
+    #   types-lxml
+unidecode==1.3.7
     # via a3m (setup.py)
-typing-extensions==4.1.1
-    # via mypy
-unidecode==1.3.4
-    # via a3m (setup.py)
-urllib3==1.26.18
+urllib3==2.0.7
     # via
     #   botocore
     #   requests
-virtualenv==20.24.2
+virtualenv==20.24.6
     # via
     #   pre-commit
     #   tox
-vulture==2.3
+vulture==2.10
     # via a3m (setup.py)
-wheel==0.41.1
+wheel==0.41.2
     # via pip-tools
-wrapt==1.14.0
-    # via astroid
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,19 +16,23 @@ attrs==23.1.0
     #   referencing
 bagit==1.8.1
     # via a3m (setup.py)
-boto3==1.28.62
+boto3==1.28.69
     # via a3m (setup.py)
-botocore==1.31.62
+botocore==1.31.69
     # via
     #   boto3
     #   s3transfer
 certifi==2023.7.22
     # via requests
-charset-normalizer==2.0.12
+charset-normalizer==3.3.1
     # via requests
-click==8.1.2
+click==8.1.7
     # via a3m (setup.py)
 django==4.2.6
+    # via
+    #   a3m (setup.py)
+    #   django-stubs-ext
+django-stubs-ext==4.2.5
     # via a3m (setup.py)
 googleapis-common-protos==1.61.0
     # via
@@ -43,9 +47,9 @@ grpcio-reflection==1.59.0
     # via a3m (setup.py)
 grpcio-status==1.59.0
     # via a3m (setup.py)
-idna==3.3
+idna==3.4
     # via requests
-jmespath==1.0.0
+jmespath==1.0.1
     # via
     #   boto3
     #   botocore
@@ -66,14 +70,14 @@ metsrw==0.4.0
     # via a3m (setup.py)
 prometheus-client==0.17.1
     # via a3m (setup.py)
-protobuf==4.24.0
+protobuf==4.24.4
     # via
     #   googleapis-common-protos
     #   grpcio-reflection
     #   grpcio-status
 pygfried==0.6.0
     # via a3m (setup.py)
-pygments==2.15.0
+pygments==2.16.1
     # via rich
 python-dateutil==2.8.2
     # via botocore
@@ -97,9 +101,11 @@ sqlparse==0.4.4
     # via django
 tenacity==8.2.3
     # via a3m (setup.py)
-unidecode==1.3.4
+typing-extensions==4.8.0
+    # via django-stubs-ext
+unidecode==1.3.7
     # via a3m (setup.py)
-urllib3==1.26.18
+urllib3==2.0.7
     # via
     #   botocore
     #   requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,7 @@ install_requires =
     pygfried~=0.6
     # Django ORM
     Django~=4.2
+    django-stubs-ext~=4.2
     # Infra
     prometheus_client~=0.17
     requests~=2.31
@@ -80,6 +81,8 @@ dev =
     pre-commit
     sphinx
     sphinxcontrib-mermaid
+    django-types
+    types-lxml
 
 
 [options.entry_points]
@@ -116,6 +119,9 @@ omit =
 ignore_missing_imports = True
 namespace_packages = True
 exclude = (?x)(^a3m/main/migrations)
+
+[mypy-a3m.main.models]
+ignore_errors = True
 
 [mypy-a3m.server.rpc.*]
 ignore_errors = True

--- a/tests/client/test_load_premis_events_from_xml.py
+++ b/tests/client/test_load_premis_events_from_xml.py
@@ -176,12 +176,14 @@ def test_parse_datetime_with_invalid_value():
 
 def test_parse_datetime_with_valid_date():
     result = load_premis_events_from_xml.parse_datetime("2019-09-24")
+    assert result is not None
     assert (2019, 9, 24) == (result.year, result.month, result.day)
     assert (0, 0, 0) == (result.hour, result.minute, result.second)
 
 
 def test_parse_datetime_with_valid_datetime_and_no_timezone():
     result = load_premis_events_from_xml.parse_datetime("2019-09-24T16:54:21")
+    assert result is not None
     assert (2019, 9, 24) == (result.year, result.month, result.day)
     assert (16, 54, 21) == (result.hour, result.minute, result.second)
     assert "UTC" == result.tzname()
@@ -189,6 +191,7 @@ def test_parse_datetime_with_valid_datetime_and_no_timezone():
 
 def test_parse_datetime_with_valid_datetime_and_timezone():
     result = load_premis_events_from_xml.parse_datetime("2019-09-24T16:54:21+04:00")
+    assert result is not None
     assert (2019, 9, 24) == (result.year, result.month, result.day)
     assert (16, 54, 21) == (result.hour, result.minute, result.second)
     assert "UTC+04:00" == result.tzname()
@@ -382,8 +385,10 @@ no_event_outcome_detail_xml = """
 
 def test_event_element_factory_with_no_event_outcome_detail():
     premis_element = etree.fromstring(no_event_outcome_detail_xml)
+    assert premis_element is not None
     event_element = premis_element.find("premis:event", premis_element.nsmap)
-    event_element.set("version", premis_element.get("version"))
+    assert event_element is not None
+    event_element.set("version", premis_element.get("version", ""))
     result = load_premis_events_from_xml.event_element_factory(event_element)
     expected_attributes = [
         "agents",

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -25,10 +25,13 @@ def registry():
 
 
 def test_registry_get_file_rules(db, registry):
+    """Confirm that it accepts uuid.UUID, str and File."""
     file_obj = create_file_with_version_id(
         "082f3282-8331-4da4-b452-632b17e90d66"
     )  # fmt/3
-    assert len(registry.get_file_rules(file_obj.pk, RulePurpose.THUMBNAIL)) == 1
+    assert len(registry.get_file_rules(file_obj.uuid, RulePurpose.THUMBNAIL)) == 1
+    assert len(registry.get_file_rules(str(file_obj.uuid), RulePurpose.THUMBNAIL)) == 1
+    assert len(registry.get_file_rules(file_obj, RulePurpose.THUMBNAIL)) == 1
 
 
 def test_registry_integrity(registry):


### PR DESCRIPTION
Using pyright because it's also the static type checker used by VSCode.

It produces 156 errors and 2 warnings with the default configuration. If fixed we could add a pre-commit check and disable mypy.

I've used [django-types](https://pypi.org/project/django-types/) that is not built as a mypy plugin making it compatible with pyright, pyre, etc... it requires some annotations to make some ORM relationships discoverable, tried a few and it works great.