### PR TITLE
Use tox without Docker

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,30 +6,75 @@ on:
     - main
 jobs:
   tests:
-    name: ${{ matrix.name }}
-    runs-on: ${{ matrix.os }}
+    name: "Test on ${{ matrix.os }}"
+    runs-on: "${{ matrix.os }}-latest"
     strategy:
       fail-fast: false
       matrix:
-        include:
-        - {name: Python 3.11, python: '3.11', os: ubuntu-latest, tox: pytest, codecov: true}
-        - {name: Python 3.12, python: '3.12', os: ubuntu-latest, tox: pytest, codecov: false}
+        os:
+        - ubuntu
     steps:
-    - name: Check out source code
-      uses: actions/checkout@v2
-    - name: "Create external volume"
-      run: |
-        make create-volume
-    - name: "Run toxenv"
-      run: |
-        make tox ARG=${{ matrix.tox }}
-      env:
-        PYTHON_VERSION: ${{ matrix.python }}
-    - name: Codecov
-      uses: codecov/codecov-action@v1
+    - name: "Check out source code"
+      uses: "actions/checkout@v4"
+    - name: "Install Python"
+      uses: "actions/setup-python@v4"
       with:
-        file: ./.coverage.xml
-      if: ${{ matrix.codecov }}
+        python-version: |
+          3.11
+          3.12
+    - name: "Restore cache"
+      id: "restore-cache"
+      uses: "actions/cache@v3"
+      with:
+        path: |
+          .tox/
+          .venv/
+        key: "cache-python-${{ steps.setup-python.outputs.python-version }}-os-${{ runner.os }}-hash-${{ hashFiles('pyproject.toml', 'requirements.txt', 'requirements-dev.txt') }}"
+    - name: "Install tox"
+      if: "steps.restore-cache.outputs.cache-hit == false"
+      run: |
+        python -m venv .venv
+        .venv/bin/python -m pip install -U setuptools
+        .venv/bin/python -m pip install tox
+    - name: "Run tox"
+      run: |
+        .venv/bin/python -m tox -e py
+    - name: "Upload coverage data"
+      uses: actions/upload-artifact@v3
+      with:
+        name: covdata
+        path: .coverage.*
+  coverage:
+    name: Coverage
+    needs: tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Check out the repo"
+        uses: "actions/checkout@v4"
+      - name: "Set up Python"
+        uses: "actions/setup-python@v4"
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: "requirements-dev.txt"
+      - name: "Install tox"
+        run: |
+          python -m pip install -U setuptools
+          python -m pip install tox
+      - name: "Download coverage data"
+        uses: actions/download-artifact@v3
+        with:
+          name: covdata
+      - name: "Combine and report"
+        run: |
+          python -m tox -e coverage
+          export TOTAL=$(python -c "import json;print(json.load(open('coverage.json'))['totals']['percent_covered_display'])")
+          echo "total=$TOTAL" >> $GITHUB_ENV
+          echo "### Total coverage: ${TOTAL}%" >> $GITHUB_STEP_SUMMARY
+      - name: "Codecov"
+        uses: codecov/codecov-action@v3
+        with:
+          files: coverage.xml
   e2e:
     name: e2e
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 # coverage data file
 .coverage
 .coverage.*
+coverage.*
 
 # pytest's working directory
 .cache

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,6 @@ A3M_PIPELINE_DATA ?= $(CURDIR)/hack/compose-volume
 CURRENT_UID := $(shell id -u)
 CURRENT_GID := $(shell id -g)
 
-NULL :=
-SPACE := $(NULL) $(NULL)
-
 define compose
 	docker compose -f docker-compose.yml $(1)
 endef
@@ -24,14 +21,6 @@ define compose_run
 		--workdir /a3m \
 		--no-deps \
 		$(1))
-endef
-
-define toxenvs
-	$(call compose_run, \
-		--entrypoint tox \
-			a3m \
-				$(subst $(SPACE), -e ,$(SPACE)$(1)) \
-				${TOXARGS})
 endef
 
 .PHONY: shell
@@ -159,14 +148,6 @@ publish-clean:
 	rm -rf a3m.egg-info/
 	rm -rf build/
 	rm -rf dist/
-
-.PHONY: tox
-tox: build  ## Run a toxenv.
-	$(call toxenvs,$(ARG))
-
-.PHONY: test
-test:  ## Run the tests with coverage.
-	$(MAKE) tox ARG="pytest"
 
 RED := \033[0;31m
 GREEN := \033[0;32m

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,15 +95,34 @@ legacy_tox_ini = """
     skipsdist = True
     min_version = 4.0
     env_list =
-        pytest
+        py3{11,12},
+        coverage,
+        tox
+    labels=
+        py = py3{11,12}
 
     [testenv]
-    deps = -r {toxinidir}/requirements-dev.txt
-
-    [testenv:pytest]
-    skip_install = True
+    deps =
+        -r {toxinidir}/requirements-dev.txt
+    passenv =
+        COVERAGE_*
     commands =
-      coverage run -m pytest {posargs} {toxinidir}/tests/
-      coverage report
-      coverage xml -o {toxinidir}/.coverage.xml
+        python -V
+        coverage run -p -m pytest -Wd {posargs}
+
+    [testenv:coverage]
+    depends = pypy311,py312
+    basepython = python3.12
+    commands =
+        coverage combine
+        coverage report -m --skip-covered
+        coverage html
+        coverage json
+        coverage xml
+    parallel_show_output = true
+
+    [testenv:pre-commit]
+    skip_install = true
+    deps = pre-commit
+    commands = pre-commit run --all-files --show-diff-on-failure
 """

--- a/setup.cfg
+++ b/setup.cfg
@@ -93,10 +93,6 @@ console_scripts =
     a3md = a3m.cli.server.__main__:main
 
 
-[tool:pytest]
-minversion = 7.0
-
-
 [flake8]
 exclude = .venv, .tox, .git, __pycache__, .cache, build, dist, *.pyc, *.egg-info, .eggs, a3m/api/**/*.py
 application-import-names = flake8


### PR DESCRIPTION
This should speed up builds significantly.

Job `e2e` is still building the container and that takes 5+ minutes, we'll see how that can be improved.

In CI, pytest is executed in parallel mode, the coverage outputs are collected and then combined to generate the report.