### PR TITLE
Add post checkout job to unshallow in rtd

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,6 +3,9 @@ build:
   os: "ubuntu-22.04"
   tools:
     python: "3.11"
+  jobs:
+    post_checkout:
+      - "git fetch --unshallow"
 sphinx:
  configuration: "docs/conf.py"
 python:


### PR DESCRIPTION
readthedocs can't look up git tags because it shallows clones by default.