### PR TITLE
Use processing config defaults in Submit handler

### DIFF
--- a/a3m/cli/client/__main__.py
+++ b/a3m/cli/client/__main__.py
@@ -14,6 +14,7 @@ from a3m.cli.client.wrapper import ClientWrapper
 from a3m.cli.common import configure_xml_catalog_files
 from a3m.cli.common import init_django
 from a3m.cli.common import suppress_warnings
+from a3m.server.processing import DEFAULT_PROCESSING_CONFIG
 from a3m.server.rpc.client import Client
 
 
@@ -97,8 +98,6 @@ def _to_int(value: str) -> int | None:
 def _prepare_config(user_pairs):
     """Consolidate ``ProcessingConfig`` defaults and user-provided.
 
-    A3M-TODO: defaults should be set on the server!
-
     ``user_pairs`` is a list of strings following the format ``key=value``.
     Those matching processing configuration attributes will be evaluated as
     indicated by the field type, e.g.:
@@ -111,23 +110,8 @@ def _prepare_config(user_pairs):
     A comprehensive list can be found in the definition of the
     ``ProcessingConfig`` message in the proto file.
     """
-    config = transfer_service_api.request_response_pb2.ProcessingConfig(
-        assign_uuids_to_directories=True,
-        examine_contents=False,
-        generate_transfer_structure_report=True,
-        document_empty_directories=True,
-        extract_packages=True,
-        delete_packages_after_extraction=False,
-        identify_transfer=True,
-        identify_submission_and_metadata=True,
-        identify_before_normalization=True,
-        normalize=True,
-        transcribe_files=True,
-        perform_policy_checks_on_originals=True,
-        perform_policy_checks_on_preservation_derivatives=True,
-        aip_compression_level=1,
-        aip_compression_algorithm=transfer_service_api.request_response_pb2.ProcessingConfig.AIP_COMPRESSION_ALGORITHM_S7_COPY,
-    )
+    config = transfer_service_api.request_response_pb2.ProcessingConfig()
+    config.CopyFrom(DEFAULT_PROCESSING_CONFIG)
     for item in user_pairs:
         head, sep, tail = item.partition("=")
         if head and sep:

--- a/a3m/server/processing.py
+++ b/a3m/server/processing.py
@@ -1,0 +1,19 @@
+from a3m.api.transferservice import v1beta1 as transfer_service_api
+
+DEFAULT_PROCESSING_CONFIG = transfer_service_api.request_response_pb2.ProcessingConfig(
+    assign_uuids_to_directories=True,
+    examine_contents=False,
+    generate_transfer_structure_report=True,
+    document_empty_directories=True,
+    extract_packages=True,
+    delete_packages_after_extraction=False,
+    identify_transfer=True,
+    identify_submission_and_metadata=True,
+    identify_before_normalization=True,
+    normalize=True,
+    transcribe_files=True,
+    perform_policy_checks_on_originals=True,
+    perform_policy_checks_on_preservation_derivatives=True,
+    aip_compression_level=1,
+    aip_compression_algorithm=transfer_service_api.request_response_pb2.ProcessingConfig.AIP_COMPRESSION_ALGORITHM_S7_COPY,
+)

--- a/a3m/server/transfer_service.py
+++ b/a3m/server/transfer_service.py
@@ -20,6 +20,7 @@ class TransferService(transfer_service_api.service_pb2_grpc.TransferServiceServi
         self.executor = executor
 
     def Submit(self, request, context):
+        config = request.config if request.HasField("config") else None
         try:
             package = Package.create_package(
                 self.package_queue,
@@ -27,7 +28,7 @@ class TransferService(transfer_service_api.service_pb2_grpc.TransferServiceServi
                 self.workflow,
                 request.name,
                 request.url,
-                request.config,
+                config,
             )
         except Exception as err:
             logger.warning("TransferService.Submit handler error: %s", err)

--- a/changelog.d/20231212_154905_jesus_processing_config_defaults.rst
+++ b/changelog.d/20231212_154905_jesus_processing_config_defaults.rst
@@ -1,0 +1,35 @@
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+.. Removed
+.. -------
+..
+.. - A bullet item for the Removed category.
+..
+.. Added
+.. -----
+..
+.. - A bullet item for the Added category.
+..
+Changed
+-------
+
+- Update the Submit RPC handler to use the default processing configuration when
+  the user-provided ``config`` field is unset.
+..
+.. Deprecated
+.. ----------
+..
+.. - A bullet item for the Deprecated category.
+..
+.. Fixed
+.. -----
+..
+.. - A bullet item for the Fixed category.
+..
+.. Security
+.. --------
+..
+.. - A bullet item for the Security category.
+..


### PR DESCRIPTION
Update the Submit RPC handler to use the default processing configuration when
the user-provided "config" field is unset. Not doing this meant that we would be using the default processing config proto object with all its fields set to false, 0, etc...