### PR TITLE
Adjust server tolerance to frequent keepalive pings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,17 @@ See the fragment files in the `changelog.d directory`_.
 
 .. scriv-insert-here
 
+.. _changelog-0.7.9:
+
+0.7.9 — 2024-02-12
+==================
+
+Fixed
+-----
+
+- Adjusted server tolenace to more frequent keepalive pings, mitigating
+  ``ENHANCE_YOUR_CALM`` errors by allowing shorter intervals between pings.
+
 .. _changelog-0.7.8:
 
 0.7.8 - 2024-02-12

--- a/a3m/__init__.py
+++ b/a3m/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.7.8"
+__version__ = "0.7.9"
 
 __all__ = ["__version__"]

--- a/a3m/server/runner.py
+++ b/a3m/server/runner.py
@@ -89,7 +89,15 @@ class Server:
             debug=debug,
         )
         self.grpc_executor = grpc_executor
-        self.grpc_server = grpc.server(grpc_executor)
+        self.grpc_server = grpc.server(
+            grpc_executor,
+            options=[
+                # Adjusted server tolerance to more frequent keepalive pings,
+                # mitigating ENHANCE_YOUR_CALM errors by allowing shorter
+                # intervals between pings.
+                ("grpc.http2.min_ping_interval_without_data_ms", 100),
+            ],
+        )
         self.grpc_port = self.grpc_server.add_insecure_port(bind_address)
 
         self._mount_services()


### PR DESCRIPTION
This avoids the following error seen in some clients while processing big transfers:

    ipv4:127.0.0.1:42625: Received a GOAWAY with error code ENHANCE_YOUR_CALM and debug data equal to "too_many_pings". Current keepalive time (before throttling): ∞