### PR TITLE
Bump buf-lint-action to v1.1.0

### DIFF
--- a/.github/workflows/buf-push.yml
+++ b/.github/workflows/buf-push.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: bufbuild/buf-setup-action@v1
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-    - uses: bufbuild/buf-lint-action@v1
+    - uses: bufbuild/buf-lint-action@v1.1.0
       with:
         input: proto
     # TODO: use buf-breaking-action when ready


### PR DESCRIPTION
Fixes a Github actions error about npm v20 being required for action runners.