### PR TITLE
Mediaarea fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,8 @@ RUN set -ex \
 	&& add-apt-repository --no-update --yes "deb http://archive.ubuntu.com/ubuntu/ jammy multiverse" \
 	&& add-apt-repository --no-update --yes "deb http://archive.ubuntu.com/ubuntu/ jammy-security universe" \
 	&& add-apt-repository --no-update --yes "deb http://archive.ubuntu.com/ubuntu/ jammy-updates multiverse" \
-	&& curl -so /tmp/repo-mediaarea_1.0-21_all.deb -L https://mediaarea.net/repo/deb/repo-mediaarea_1.0-21_all.deb \
-	&& dpkg -i /tmp/repo-mediaarea_1.0-21_all.deb \
+	&& curl -so /tmp/repo-mediaarea_1.0-25_all.deb -L https://mediaarea.net/repo/deb/repo-mediaarea_1.0-25_all.deb \
+	&& dpkg -i /tmp/repo-mediaarea_1.0-25_all.deb \
 	&& apt-get update \
 	&& apt-get install -y --no-install-recommends \
 	atool \
@@ -55,6 +55,7 @@ RUN set -ex \
 	libimage-exiftool-perl \
 	libevent-dev \
 	libjansson4 \
+	mediainfo \
 	openjdk-8-jre-headless \
 	p7zip-full \
 	pbzip2 \

--- a/a3m/client/clientScripts/characterize_file.py
+++ b/a3m/client/clientScripts/characterize_file.py
@@ -120,10 +120,10 @@ def main(job, file_path, file_uuid, sip_uuid):
 
         # Save outputs if they are the same
         for file_uuid, rule, stdout in state:
-            _insert_command_output(file_uuid, rule.uuid, stdout)
+            _insert_command_output(file_uuid, rule.id, stdout)
             job.write_output(
                 'Saved XML output for command "{}" ({})'.format(
-                    rule.command.description, rule.command.uuid
+                    rule.command.description, rule.command.id
                 )
             )
 


### PR DESCRIPTION
MediaArea Repo used in Dockerfile is obsolete. Resulting in build failure.  As mentioned in #466

- Updated to the latest version `repo-mediaarea_1.0-25_all.deb`.
- Fixed subsequent errors in "Characterize and extract metadata" task:
  - `mediainfo: command not found` - add mediainfo package to package install list
  - `'Rule' object has no attribute 'uuid'` - fix incorrect usage of `Rule.uuid` and `Command.Uuid` - should be `id`

TODO:
- FFprobe error in "Characterize and extract metadata" task - `File not found - %fileFullName%`