### PR TITLE
Bump Django to 4.2.30 (security)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -312,16 +312,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "4.2.16"
+version = "4.2.30"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/65/d8/a607ee443b54a4db4ad28902328b906ae6218aa556fb9b3ac45c0bcb313d/Django-4.2.16.tar.gz", hash = "sha256:6f1616c2786c408ce86ab7e10f792b8f15742f7b7b7460243929cb371e7f1dad", size = 10436023 }
+sdist = { url = "https://files.pythonhosted.org/packages/11/b5/f1a53dc68da6429d6e0345bb848161e2381a2e9f02700148911e8582c2b3/django-4.2.30.tar.gz", hash = "sha256:4ebc7a434e3819db6cf4b399fb5b3f536310a30e8486f08b66886840be84b37c", size = 10468707 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/2c/6b6c7e493d5ea789416918658ebfa16be7a64c77610307497ed09a93c8c4/Django-4.2.16-py3-none-any.whl", hash = "sha256:1ddc333a16fc139fd253035a1606bb24261951bbc3a6ca256717fa06cc41a898", size = 7992936 },
+    { url = "https://files.pythonhosted.org/packages/39/b7/a7c96f239cf91313a6589233fed55111c7063b26683b226802732c455dbc/django-4.2.30-py3-none-any.whl", hash = "sha256:4d07aaf1c62f9984842b67c2874ebbf7056a17be253860299b93ae1881faad65", size = 7997231 },
 ]
 
 [[package]]


### PR DESCRIPTION
`main`'s lockfile resolves Django to **4.2.16** (Sept 2024). This regenerates the lock entry to **4.2.30**, the final Django 4.2 LTS release, picking up every security release since 4.2.16, including the SQL-injection fixes in 4.2.25 (column aliases on MySQL/MariaDB) and 4.2.27 (FilteredRelation on PostgreSQL).

Lockfile-only change; the `Django~=4.2` constraint in `pyproject.toml` already permits it. Regenerated with `uv lock --upgrade-package django` and reduced to the Django entry alone (dropped incidental uv-version reformatting noise).

Note: 4.2.30 is the final 4.2 release (extended support ended 2026-04-07), so this is a fully-patched but interim step on the 4.2 line.
